### PR TITLE
added kstat support for tunable zfs_removal_suspend_progress

### DIFF
--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -147,6 +147,7 @@ typedef struct windows_kstat {
 	kstat_named_t zfs_vdev_initialize_value;
 	kstat_named_t zfs_autoimport_disable;
 	kstat_named_t zfs_total_memory_limit;
+	kstat_named_t zfs_removal_suspend_progress;
 } windows_kstat_t;
 
 
@@ -255,6 +256,7 @@ extern uint64_t zfs_disable_removablemedia;
 
 extern uint64_t zfs_initialize_value;
 extern int zfs_autoimport_disable;
+extern int zfs_removal_suspend_progress;
 
 int  kstat_windows_init(void *);
 void kstat_windows_fini(void);

--- a/module/os/windows/zfs/zfs_kstat_windows.c
+++ b/module/os/windows/zfs/zfs_kstat_windows.c
@@ -171,6 +171,7 @@ windows_kstat_t windows_kstat = {
 	{ "zfs_vdev_initialize_value",		KSTAT_DATA_UINT64 },
 	{ "zfs_autoimport_disable",		KSTAT_DATA_UINT64 },
 	{ "zfs_total_memory_limit",		KSTAT_DATA_UINT64 },
+	{ "zfs_removal_suspend_progress",	KSTAT_DATA_INT32 }
 };
 
 
@@ -376,6 +377,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->zfs_vdev_initialize_value.value.ui64;
 		zfs_autoimport_disable =
 		    ks->zfs_autoimport_disable.value.ui64;
+		zfs_removal_suspend_progress =
+		    ks->zfs_removal_suspend_progress.value.i32;
 
 	} else {
 
@@ -561,6 +564,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    zfs_initialize_value;
 		ks->zfs_autoimport_disable.value.ui64 =
 		    zfs_autoimport_disable;
+		ks->zfs_removal_suspend_progress.value.i32 =
+		    zfs_removal_suspend_progress;
 	}
 	arc_kstat_update_windows(ksp, rw);
 	return (0);


### PR DESCRIPTION
The ZTS test 'functional/removal/removal_with_add.ksh' requires the support to set the tunable parameter 'zfs_removal_suspend_progress'. This value can be set using kstat.exe.
