### PR TITLE
changing the datatype of zfs_arc_meta_limit to uint64_t

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -108,7 +108,7 @@ zdb_ot_name(dmu_object_type_t type)
 
 extern int reference_tracking_enable;
 extern int zfs_recover;
-extern unsigned long zfs_arc_meta_min, zfs_arc_meta_limit;
+extern uint64_t zfs_arc_meta_min, zfs_arc_meta_limit;
 extern int zfs_vdev_async_read_max_active;
 extern boolean_t spa_load_verify_dryrun;
 extern int zfs_reconstruct_indirect_combinations_max;

--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -160,8 +160,8 @@ extern uint64_t vnop_num_vnodes;
 extern uint64_t vnop_num_reclaims;
 extern uint32_t spl_hostid;
 
-extern unsigned long zfs_arc_max;
-extern unsigned long zfs_arc_min;
+extern uint64_t zfs_arc_max;
+extern uint64_t zfs_arc_min;
 extern uint64_t zfs_arc_meta_limit;
 extern uint64_t zfs_arc_meta_min;
 extern int zfs_arc_grow_retry;

--- a/include/sys/arc_impl.h
+++ b/include/sys/arc_impl.h
@@ -979,8 +979,8 @@ extern arc_state_t	*arc_mfu;
 extern arc_state_t	*arc_mru;
 extern uint_t zfs_arc_pc_percent;
 extern int arc_lotsfree_percent;
-extern unsigned long zfs_arc_min;
-extern unsigned long zfs_arc_max;
+extern uint64_t zfs_arc_min;
+extern uint64_t zfs_arc_max;
 
 extern void arc_reduce_target_size(int64_t to_free);
 extern boolean_t arc_reclaim_needed(void);

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -670,8 +670,8 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 			    zfs_arc_min == 0)
 				arc_c_min = arc_meta_limit / 2;
 
-			dprintf("ZFS: set arc_meta_limit %lu, arc_c_min %lu,"
-			    "zfs_arc_meta_limit %lu\n",
+			dprintf("ZFS: set arc_meta_limit %llu, arc_c_min %llu,"
+			    "zfs_arc_meta_limit %llu\n",
 			    arc_meta_limit, arc_c_min, zfs_arc_meta_limit);
 		}
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -417,10 +417,10 @@ boolean_t arc_warm;
 /*
  * These tunables are for performance analysis.
  */
-unsigned long zfs_arc_max = 0;
-unsigned long zfs_arc_min = 0;
-unsigned long zfs_arc_meta_limit = 0;
-unsigned long zfs_arc_meta_min = 0;
+uint64_t zfs_arc_max = 0;
+uint64_t zfs_arc_min = 0;
+uint64_t zfs_arc_meta_limit = 0;
+uint64_t zfs_arc_meta_min = 0;
 unsigned long zfs_arc_dnode_limit = 0;
 unsigned long zfs_arc_dnode_reduce_percent = 10;
 int zfs_arc_grow_retry = 0;
@@ -7480,7 +7480,7 @@ void
 arc_tuning_update(boolean_t verbose)
 {
 	uint64_t allmem = arc_all_memory();
-	unsigned long limit;
+	uint64_t limit;
 
 	/* Valid range: 32M - <arc_c_max> */
 	if ((zfs_arc_min) && (zfs_arc_min != arc_c_min) &&


### PR DESCRIPTION
As described in #63, the arc limit values gets truncate for larger numbers. As windows uses LLP64 model, long is 4 bytes where as 8 bytes(LP64) in Linux.. So using uint64_t for the arc limit values.