### PR TITLE
Import failure during disk removal

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -1062,9 +1062,11 @@ make_disks(zpool_handle_t *zhp, nvlist_t *nv)
 				return (ret);
 			}
 
+#ifndef _WIN32
 			ret = zero_label(udevpath);
 			if (ret)
 				return (ret);
+#endif
 #ifdef _WIN32
 			/*
 			 * Append_partition will only work once label_disk has

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -2438,6 +2438,20 @@ vdev_copy_path_impl(vdev_t *svd, vdev_t *dvd)
 		zfs_dbgmsg("vdev_copy_path: vdev %llu: path set to '%s'",
 		    (u_longlong_t)dvd->vdev_guid, dvd->vdev_path);
 	}
+	if (svd->vdev_physpath != NULL && dvd->vdev_physpath != NULL) {
+	    if (strcmp(svd->vdev_physpath, dvd->vdev_physpath) != 0) {
+		zfs_dbgmsg("vdev_copy_path: vdev %llu: physpath changed "
+		    "from '%s' to '%s'", (u_longlong_t)dvd->vdev_guid,
+		    dvd->vdev_physpath, svd->vdev_physpath);
+		spa_strfree(dvd->vdev_physpath);
+		dvd->vdev_physpath = spa_strdup(svd->vdev_physpath);
+	    }
+	}
+	else if (svd->vdev_physpath != NULL) {
+	    dvd->vdev_physpath = spa_strdup(svd->vdev_physpath);
+	    zfs_dbgmsg("vdev_copy_path: vdev %llu: physpath set to '%s'",
+		(u_longlong_t)dvd->vdev_guid, dvd->vdev_physpath);
+	}
 }
 
 /*


### PR DESCRIPTION
During Pool Creation partition and label not created for the disks and import failure if the disk is removed and order has been changed for RAID group

