### PR TITLE
Cancel the bsd-timers before driver unload

### DIFF
--- a/include/os/windows/spl/sys/kmem.h
+++ b/include/os/windows/spl/sys/kmem.h
@@ -78,6 +78,7 @@ void spl_kmem_init(uint64_t);
 void spl_kmem_thread_init();
 void spl_kmem_mp_init();
 void spl_kmem_thread_fini();
+void spl_kmem_timer_fini();
 void spl_kmem_fini();
 
 uint64_t kmem_size(void);

--- a/include/os/windows/spl/sys/vmem.h
+++ b/include/os/windows/spl/sys/vmem.h
@@ -137,6 +137,7 @@ typedef void *(vmem_ximport_t)(vmem_t *, size_t *, size_t, int);
 extern vmem_t *vmem_init(const char *, void *, size_t, size_t,
     vmem_alloc_t *, vmem_free_t *);
 extern void    vmem_fini(vmem_t *);
+extern void vmem_timer_fini();
 extern void vmem_update(void *);
 extern int vmem_is_populator();
 extern size_t vmem_seg_size;

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -5382,6 +5382,14 @@ spl_kmem_thread_fini(void)
 }
 
 void
+spl_kmem_timer_fini(void)
+{
+	bsd_timeout_cancel(&kmem_update_timer);
+	bsd_timeout_cancel(&kmem_reaping);
+	bsd_timeout_cancel(&kmem_reaping_idspace);
+}
+
+void
 spl_kmem_mp_init(void)
 {
 	kmem_update_timeout(&kmem_update_timer);

--- a/module/os/windows/spl/spl-lookasidelist.c
+++ b/module/os/windows/spl/spl-lookasidelist.c
@@ -135,13 +135,14 @@ lookasidelist_cache_destroy(lookasidelist_cache_t *pLookasidelist_cache)
 	if (pLookasidelist_cache != NULL) {
 		ExFlushLookasideListEx(&pLookasidelist_cache->lookasideField);
 		ExDeleteLookasideListEx(&pLookasidelist_cache->lookasideField);
-		ExFreePoolWithTag(pLookasidelist_cache,
-		    ZFS_LookAsideList_DRV_TAG);
 
 		if (pLookasidelist_cache->cache_kstat != NULL) {
 			kstat_delete(pLookasidelist_cache->cache_kstat);
 			pLookasidelist_cache->cache_kstat = NULL;
 		}
+
+		ExFreePoolWithTag(pLookasidelist_cache,
+		    ZFS_LookAsideList_DRV_TAG);
 	}
 }
 

--- a/module/os/windows/spl/spl-vmem.c
+++ b/module/os/windows/spl/spl-vmem.c
@@ -3564,6 +3564,12 @@ vmem_fini_void(void *vmp, void *start, size_t size)
 }
 
 void
+vmem_timer_fini()
+{
+	bsd_timeout_cancel(&vmem_update_timer);
+}
+
+void
 vmem_fini(vmem_t *heap)
 {
 	struct free_slab *fs;

--- a/module/os/windows/spl/spl-windows.c
+++ b/module/os/windows/spl/spl-windows.c
@@ -554,6 +554,15 @@ spl_stop(void)
 		IOLog("SPL: active threads %d\n", zfs_threads);
 		delay(hz << 2);
 	}
+
+	/*
+	 * At this point, all threads waiting on bsd_timers in
+	 * bsd_timeout_handler() are exited and timer can be cancelled. If the
+	 * timer is still loaded,it could fire after driver unload and bugcheck
+	 */
+	spl_kmem_timer_fini();
+	vmem_timer_fini();
+
 	return (STATUS_SUCCESS);
 }
 


### PR DESCRIPTION
Merge commits:
1) Free the lookasidelist_cache and its kstat member pointer in correct order
2) Cancel the bsd-timers before driver unload
