### PR TITLE
ZFS-1180: Change the disk name "PHYSICALDRIVE" to lowercase in the configuration.

### DIFF
--- a/scripts/zts_windows/zts_util_func.py
+++ b/scripts/zts_windows/zts_util_func.py
@@ -249,7 +249,7 @@ def export_disk():
     disk_no = disk.split(',')
     disk_path =''
     for i in disk_no:
-        disk_path = disk_path+"PHYSICALDRIVE"+i+" "
+        disk_path = disk_path+"physicaldrive"+i+" "
     disk_path = '"'+disk_path.strip()+'"'
     print(disk_path)
     return disk_path


### PR DESCRIPTION
case sensitive string compare in the ZFS tests were failing as the "zpool status" lists the disk name in lower case and our configuration was passing the disk name in upper case.