### PR TITLE
Enable pre and post script for Cache. Run zpool, zfs list tests as root

### DIFF
--- a/tests/runfiles/windows-All.run
+++ b/tests/runfiles/windows-All.run
@@ -46,13 +46,11 @@ tags = ['functional', 'cli_root', 'zfs_create']
 
 [tests/functional/cli_user/zpool_list]
 tests = ['zpool_list_001_pos', 'zpool_list_002_neg']
-user =
 tags = ['functional', 'cli_user', 'zpool_list']
 
 [tests/functional/cli_user/zfs_list]
 tests = ['zfs_list_001_pos', 'zfs_list_002_pos', 'zfs_list_003_pos',
     'zfs_list_004_neg', 'zfs_list_008_neg']
-user =
 tags = ['functional', 'cli_user', 'zfs_list']
 
 [tests/functional/cli_root/zpool_set]
@@ -115,8 +113,6 @@ post =
 tags = ['functional', 'pool_names']
 
 [tests/functional/cache]
-pre =
-post=
 tests = ['cache_001_pos', 'cache_002_pos', 'cache_003_pos', 'cache_004_neg',
     'cache_005_neg','cache_007_neg', 'cache_008_neg',
     'cache_009_pos', 'cache_011_pos']

--- a/tests/zfs-tests/tests/functional/cache/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cache/cleanup.ksh
@@ -34,13 +34,13 @@
 
 verify_runnable "global"
 
-if datasetexists $TESTPOOL ; then
-	log_must zpool destroy -f $TESTPOOL
-fi
-if datasetexists $TESTPOOL2 ; then
-	log_must zpool destroy -f $TESTPOOL2
-fi
+#if datasetexists $TESTPOOL ; then
+#	log_must zpool destroy -f $TESTPOOL
+#fi
+#if datasetexists $TESTPOOL2 ; then
+#	log_must zpool destroy -f $TESTPOOL2
+#fi
 
-log_must rm -rf $VDIR $VDIR2
+#log_must rm -rf $VDIR $VDIR2
 
 log_pass

--- a/tests/zfs-tests/tests/functional/cache/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cache/setup.ksh
@@ -34,8 +34,8 @@
 
 verify_runnable "global"
 
-log_must rm -rf $VDIR $VDIR2
-log_must mkdir -p $VDIR $VDIR2
-log_must mkfile $SIZE $VDEV $VDEV2
+#log_must rm -rf $VDIR $VDIR2
+#log_must mkdir -p $VDIR $VDIR2
+#log_must mkfile $SIZE $VDEV $VDEV2
 
 log_pass


### PR DESCRIPTION
ZFS-1180: ZFS tests failed on Linux as pre, post scripts were not executed. zfs and zpool list tests to be run as root.