### PR TITLE
zdb dump block: Debug assert fail for isprint() when char value > 127…

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -7787,7 +7787,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 	int do_bswap = !!(flags & ZDB_FLAG_BSWAP);
 	unsigned i, j;
 	const char *hdr;
-	char *c;
+	unsigned char *c;
 
 
 	if (do_bswap)
@@ -7807,7 +7807,7 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i]) : d[i]),
 		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i + 1]) : d[i + 1]));
 
-		c = (char *)&d[i];
+		c = (unsigned char *)&d[i];
 		for (j = 0; j < 2 * sizeof (uint64_t); j++)
 			(void) printf("%c", isprint(c[j]) ? c[j] : '.');
 		(void) printf("\n");


### PR DESCRIPTION
merge pull request https://github.com/openzfsonwindows/openzfs/pull/101