### PR TITLE
Skip dprintf in a DPC

### DIFF
--- a/module/os/windows/zfs/zfs_debug.c
+++ b/module/os/windows/zfs/zfs_debug.c
@@ -204,6 +204,13 @@ __dprintf(boolean_t dprint, const char *file, const char *func,
 	const char *newfile;
 
 	/*
+	 * Skip everything if we can't write to the debug log due to
+	 * being in a DPC.
+	 */
+	if (KeGetCurrentIrql() >= DISPATCH_LEVEL)
+		return;
+
+	/*
 	 * Get rid of annoying prefix to filename.
 	 */
 	newfile = strrchr(file, '/');


### PR DESCRIPTION
Add a check to dprintf() that will avoid trying to write to the debug log if we are in a IRQL of DISPATCH_LEVEL or higher.
Otherwise we will get a BSOD when trying to acquire mutex.