### PR TITLE
zfs-1295: Rebuild from VS shows build as failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_compile_options(
 	-Wno-missing-field-initializers
 	#-fms-extensions
 	-Wno-unused-function
+	-Wno-unused-label
 )
 endfunction()
 


### PR DESCRIPTION
Unused label was causing compiler warning/error. So added a compile option to ignore it.