### PR TITLE
check the SRB DataBuffer length before writing lunListLength

### DIFF
--- a/module/os/windows/zfs/zfs_windows_zvol_scsi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_scsi.c
@@ -885,8 +885,13 @@ ScsiOpReportLuns(
 		}
 	}
 
-	*((ULONG*)&pLunList->LunListLength) =
-	    RtlUlongByteSwap(totalLun * sizeof (pLunList->Lun[0]));
+	if (pSrb->DataTransferLength >=
+	    FIELD_OFFSET(LUN_LIST, LunListLength) +
+	    sizeof (pLunList->LunListLength)) {
+		*((ULONG*)&pLunList->LunListLength) =
+		    RtlUlongByteSwap(totalLun * sizeof (pLunList->Lun[0]));
+	}
+
 	pSrb->DataTransferLength = FIELD_OFFSET(LUN_LIST, Lun) +
 	    (GoodLunIdx * sizeof (pLunList->Lun[0]));
 


### PR DESCRIPTION
ZFS-1316: Bugcheck in openzfs driver in SCSIOP_REPORT_LUNS request.
Changes: In the SCSIOP_REPORT_LUNS request handler, check the SRB DataBuffer length before writing lunListLength to avoid overflow.