### PR TITLE
SSV-21953 - Modified default value of 'zfs_txg_timeout' from 5 to 1 sec

### DIFF
--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -111,7 +111,7 @@
 static void txg_sync_thread(void *arg);
 static void txg_quiesce_thread(void *arg);
 
-int zfs_txg_timeout = 5;	/* max seconds worth of delta per txg */
+int zfs_txg_timeout = 1;	/* max seconds worth of delta per txg */
 
 /*
  * Prepare the txg subsystem.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The approach with syncing the TXGs quicker

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With Openzfs integrated with SSY, we always set option "sync=always" which will 100%
trigger synchronous IO. So reducing the timeout will reduce the amount of pending dirty data
