### PR TITLE
use NonPagedPoolNx during memory alloc to pass HLK test

### DIFF
--- a/module/os/windows/spl/spl-lookasidelist.c
+++ b/module/os/windows/spl/spl-lookasidelist.c
@@ -83,7 +83,7 @@ lookasidelist_cache_create(char *name,	/* descriptive name for this cache */
     size_t size) /* size of the objects it manages */
 {
 	lookasidelist_cache_t *pLookasidelist_cache;
-	pLookasidelist_cache = ExAllocatePoolWithTag(NonPagedPool,
+	pLookasidelist_cache = ExAllocatePoolWithTag(NonPagedPoolNx,
 	    sizeof (lookasidelist_cache_t), ZFS_LookAsideList_DRV_TAG);
 
 	if (pLookasidelist_cache != NULL) {

--- a/module/os/windows/zfs/zfs_windows_zvol_scsi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_scsi.c
@@ -1088,7 +1088,7 @@ DiReadWriteSetup(zvol_state_t *zv, MpWkRtnAction action, zfsiodesc_t *pIo)
 	// cannot use kmem_alloc with sleep if IRQL dispatch so get straight
 	// from NP pool.
 	pMP_WorkRtnParms pWkRtnParms = (pMP_WorkRtnParms)ExAllocatePoolWithTag(
-	    NonPagedPool, ALIGN_UP_BY(sizeof (MP_WorkRtnParms), 16) +
+	    NonPagedPoolNx, ALIGN_UP_BY(sizeof (MP_WorkRtnParms), 16) +
 	    IoSizeofWorkItem(), MP_TAG_GENERAL);
 	if (NULL == pWkRtnParms) {
 		if (pIo->Cb) {


### PR DESCRIPTION
SSV-22058- HLK test "Hypervisor-Protected Code Integrity test" failed for Openzfs.

https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/code-integrity-checking
