### PR TITLE
During zpool import, do not search zpool labels in volumes

### DIFF
--- a/lib/libzutil/os/windows/zutil_import_os.c
+++ b/lib/libzutil/os/windows/zutil_import_os.c
@@ -994,7 +994,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 #endif
 	} // while SetupDiEnumDeviceInterfaces
 
-#if 1
+#if 0
 	/* Now lets iterate the partitions (volumes) */
 	HANDLE vol;
 	vol = FindFirstVolume(rdsk, sizeof (rdsk));


### PR DESCRIPTION
As discussed with the ZFS community, this PR optimizes the zpool import workflow. During import, we can skip searching for zpool labels in volumes.

https://github.com/openzfsonwindows/ZFSin/issues/351