### PR TITLE
Implemented WPP tracing for zpool executable and added few logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,27 @@ function(tmh_generation CSOURCES TMH_FILE_LIST)
 		-func:${DPRINT} -gen:{km-default.tpl}*.tmh ${C_FILE}
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" DEPENDS ${C_FILE})
 
-		message(STATUS "FILES_IN ======: ${CMAKE_SOURCE_DIR}/out/build/${OUTPUT_FILE_WE}.tmh")
+		message(STATUS "Kernel Mode FILES_IN ======: ${CMAKE_SOURCE_DIR}/out/build/${OUTPUT_FILE_WE}.tmh")
+	endforeach()
+	set(TMH_FILE_LIST ${LOCAL_TMH_FILE_LIST} PARENT_SCOPE)
+endfunction()
+
+function(tmh_generation_for_usermode CSOURCES TMH_FILE_LIST)
+	foreach (C_FILE ${CSOURCES})
+		get_filename_component(OUTPUT_FILE_WE ${C_FILE} NAME_WE)
+		get_filename_component(WORK_DIRECTORY ${C_FILE} DIRECTORY)
+		set(TMH_FILE  ${CMAKE_SOURCE_DIR}/out/build/${OUTPUT_FILE_WE}.tmh)
+		set_source_files_properties(${C_FILE} PROPERTIES COMPILE_FLAGS -DWPPFILE=${TMH_FILE})
+		set(LOCAL_TMH_FILE_LIST ${LOCAL_TMH_FILE_LIST} ${TMH_FILE})
+
+		add_custom_command(OUTPUT ${TMH_FILE}
+		COMMAND         "${WPP_DIR}/${WDK_PLATFORM}/tracewpp.exe"
+		-scan:${SCAN} /D${WPP_MACRO}
+		-cfgdir:${CFGDIR} -I${CMAKE_CURRENT_BINARY_DIR} -odir:"${CMAKE_SOURCE_DIR}/out/build" -p:usermode -func:${TRACE}
+		-func:${DPRINT} ${C_FILE}
+		WORKING_DIRECTORY "${WORK_DIRECTORY}" DEPENDS ${C_FILE})
+
+		message(STATUS "User Mode FILES_IN ======: ${CMAKE_SOURCE_DIR}/out/build/${OUTPUT_FILE_WE}.tmh")
 	endforeach()
 	set(TMH_FILE_LIST ${LOCAL_TMH_FILE_LIST} PARENT_SCOPE)
 endfunction()

--- a/cmd/zpool/CMakeLists.txt
+++ b/cmd/zpool/CMakeLists.txt
@@ -3,6 +3,10 @@ use_clang()
 
 include_directories(PRIVATE "${CMAKE_SOURCE_DIR}/cmd/zpool")
 
+file(GLOB CSOURCES CONFIGURE_DEPENDS "*.c")
+set(TMH_FILE_LIST "")
+tmh_generation_for_usermode("${CSOURCES}" TMH_FILE_LIST)
+
 um_add_executable(zpool
 	zpool_iter.c
 	zpool_main.c
@@ -11,6 +15,7 @@ um_add_executable(zpool
 	zpool_util.h
 	os/windows/zpool_vdev_os.c
 	os/windows/resource.rc
+	${TMH_FILE_LIST}
 )
 target_link_libraries(zpool PRIVATE
 	libnvpair

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -78,6 +78,7 @@
 #include "zfeature_common.h"
 
 #include "statcommon.h"
+#include "os/windows/Trace.h"
 
 libzfs_handle_t *g_zfs;
 
@@ -10628,6 +10629,7 @@ zpool_do_load_compat(const char *compat, boolean_t *list)
 int
 main(int argc, char **argv)
 {
+	WPP_INIT_TRACING(L"zpool");
 	int ret = 0;
 	int i = 0;
 	char *cmdname;
@@ -10730,6 +10732,6 @@ main(int argc, char **argv)
 		(void) printf("dumping core by request\n");
 		abort();
 	}
-
+	WPP_CLEANUP();
 	return (ret);
 }

--- a/include/os/windows/Trace.h
+++ b/include/os/windows/Trace.h
@@ -59,7 +59,8 @@ static const int TRACE_NOISY = 8;
 #define	WPP_CHECK_INIT
 #endif
 
-
+#ifdef _KERNEL
 void ZFSWppInit(PDRIVER_OBJECT pDriverObject, PUNICODE_STRING pRegistryPath);
 
 void ZFSWppCleanup(PDRIVER_OBJECT pDriverObject);
+#endif

--- a/lib/libzfs/libzfs_import.c
+++ b/lib/libzfs/libzfs_import.c
@@ -39,6 +39,7 @@
 #include "libzfs_impl.h"
 #include <libzutil.h>
 #include <sys/arc_impl.h>
+#include "os/windows/Trace.h"
 
 /*
  * Returns true if the named pool matches the given GUID.
@@ -84,6 +85,7 @@ refresh_config(libzfs_handle_t *hdl, nvlist_t *config)
 		return (NULL);
 	}
 
+	TraceEvent(TRACE_INFO,"Going to call ZFS_IOC_POOL_TRYIMPORT IOCTL");
 	while ((err = zfs_ioctl(hdl, ZFS_IOC_POOL_TRYIMPORT,
 	    &zc)) != 0 && errno == ENOMEM) {
 		if (zcmd_expand_dst_nvlist(hdl, &zc) != 0) {
@@ -91,7 +93,7 @@ refresh_config(libzfs_handle_t *hdl, nvlist_t *config)
 			return (NULL);
 		}
 	}
-
+	TraceEvent(TRACE_INFO,"After ZFS_IOC_POOL_TRYIMPORT IOCTL");
 	if (err) {
 		zcmd_free_nvlists(&zc);
 		return (NULL);

--- a/lib/libzutil/CMakeLists.txt
+++ b/lib/libzutil/CMakeLists.txt
@@ -3,6 +3,13 @@ use_clang()
 
 target_include_directories(libspl BEFORE PUBLIC "")
 
+file(GLOB CSOURCES CONFIGURE_DEPENDS "*.c")
+file(GLOB CSOURCES_SUBDIR CONFIGURE_DEPENDS "os/windows/*.c")
+set(CSOURCES_COMBINED ${CSOURCES} ${CSOURCES_SUBDIR})
+
+set(TMH_FILE_LIST "")
+tmh_generation_for_usermode("${CSOURCES_COMBINED}" TMH_FILE_LIST)
+
 add_library(libzutil
 	zutil_device_path.c
 	zutil_import.c
@@ -11,6 +18,7 @@ add_library(libzutil
 	os/windows/zutil_compat.c
 	os/windows/zutil_device_path_os.c
 	os/windows/zutil_import_os.c
+	${TMH_FILE_LIST}
 )
 
 target_link_libraries(libzutil PUBLIC

--- a/lib/libzutil/os/windows/zutil_import_os.c
+++ b/lib/libzutil/os/windows/zutil_import_os.c
@@ -70,6 +70,7 @@
 #include <sys/efi_partition.h>
 
 #include "zutil_import.h"
+#include "os/windows/Trace.h"
 
 #ifdef HAVE_LIBUDEV
 #include <libudev.h>
@@ -289,6 +290,8 @@ static int
 zpool_read_label_win(HANDLE h, off_t offset, uint64_t len,
     nvlist_t **config, int *num_labels)
 {
+	DWORD threadID = GetCurrentThreadId();
+	TraceEvent(TRACE_INFO," zpool_read_label_win function started ThreadID:%lu", threadID);
 	int l, count = 0;
 	vdev_label_t *label;
 	nvlist_t *expected_config = NULL;
@@ -301,8 +304,10 @@ zpool_read_label_win(HANDLE h, off_t offset, uint64_t len,
 	drivesize = len;
 	size = P2ALIGN_TYPED(drivesize, sizeof (vdev_label_t), uint64_t);
 
-	if ((label = malloc(sizeof (vdev_label_t))) == NULL)
-		return (-1);
+	if ((label = malloc(sizeof(vdev_label_t))) == NULL) {
+	    TraceEvent(TRACE_INFO,"zpool_read_label_win func return.malloc() failed ThreadID:%lu", threadID);
+	    return (-1);
+	}
 
 	for (l = 0; l < VDEV_LABELS; l++) {
 		uint64_t state, guid, txg;
@@ -351,7 +356,7 @@ zpool_read_label_win(HANDLE h, off_t offset, uint64_t len,
 
 	free(label);
 	*config = expected_config;
-
+	TraceEvent(TRACE_INFO,"zpool_read_label_win func return.ThreadID:%lu", threadID);
 	return (0);
 }
 
@@ -383,6 +388,8 @@ zpool_open_func(void *arg)
 	uint64_t len = 0;
 	uint64_t drive_len;
 
+	DWORD threadID = GetCurrentThreadId();
+	TraceEvent(TRACE_INFO, "zpool_open_func_win started ThreadID:%lu", threadID);
 	// Check if this filename is encoded with "#start#len#name"
 	if (rn->rn_name[0] == '#') {
 		char *end = NULL;
@@ -391,6 +398,8 @@ zpool_open_func(void *arg)
 		while (end && *end == '#') end++;
 		len = strtoull(end, &end, 10);
 		while (end && *end == '#') end++;
+
+		TraceEvent(TRACE_INFO,"calling createfile for rn->rn_name:%s ThreadID:%lu", rn->rn_name, threadID);
 		fd = CreateFile(end,
 		    GENERIC_READ,
 		    FILE_SHARE_READ /* | FILE_SHARE_WRITE */,
@@ -400,12 +409,19 @@ zpool_open_func(void *arg)
 		    NULL);
 		if (fd == INVALID_HANDLE_VALUE) {
 			int error = GetLastError();
+			TraceEvent(TRACE_INFO,"zpool_open_func func return.CreateFile failed with error %lu.rn->rn_name:%s ThreadID:%lu", error, rn->rn_name, threadID);
 			return;
 		}
 		LARGE_INTEGER place;
 		place.QuadPart = offset;
 		// If it fails, we cant read label
-		SetFilePointerEx(fd, place, NULL, FILE_BEGIN);
+		TraceEvent(TRACE_INFO,"Call SetFilePointerEx: offset:%lld,rn->rn_name:%s ThreadID:%lu", place.QuadPart, rn->rn_name, threadID);
+		BOOL retval = SetFilePointerEx(fd, place, NULL, FILE_BEGIN);
+
+		if (retval)
+		    TraceEvent(TRACE_INFO,"SetFilePointerEx:success. rn->rn_name:%s ThreadID:%lu", rn->rn_name, threadID);
+		else
+		    TraceEvent(TRACE_INFO,"SetFilePointerEx:failed with error.%lu rn->rn_name:%s ThreadID:%lu", GetLastError(), rn->rn_name, threadID);
 		drive_len = len;
 
 	} else {
@@ -414,6 +430,7 @@ zpool_open_func(void *arg)
 		// snprintf(fullpath, sizeof (fullpath), "%s%s",
 		// 	"", rn->rn_name);
 		zfs_backslashes(rn->rn_name);
+		TraceEvent(TRACE_INFO,"calling createfile() rn->rn_name :%s ThreadID:%lu", rn->rn_name, threadID);
 		fd = CreateFile(rn->rn_name,
 		    GENERIC_READ,
 		    FILE_SHARE_READ /* | FILE_SHARE_WRITE */,
@@ -423,18 +440,23 @@ zpool_open_func(void *arg)
 		    NULL);
 		if (fd == INVALID_HANDLE_VALUE) {
 			int error = GetLastError();
+			TraceEvent(TRACE_INFO,"func return.CreateFile() failed with error %lu.FullPath:%s ThreadID:%lu", error, rn->rn_name, threadID);
 			return;
 		}
 
+		TraceEvent(TRACE_INFO,"Get GetFileDriveSize().FullPath:%s ThreadID:%lu", rn->rn_name, threadID);
 		drive_len = GetFileDriveSize(fd);
 	}
 
+	TraceEvent(TRACE_INFO,"GetFileType() ThreadID:%lu", threadID);
 	DWORD type = GetFileType(fd);
 
+	TraceEvent(TRACE_INFO,"GetDriveType(),filetype=%d ThreadID:%lu", type, threadID);
 	/* this file is too small to hold a zpool */
 	if (type == FILE_TYPE_DISK &&
 	    drive_len < SPA_MINDEVSIZE) {
 		CloseHandle(fd);
+		TraceEvent(TRACE_INFO,"zpool_open_func function returning");
 		return;
 	}
 // else if (type != FILE_TYPE_DISK) {
@@ -449,12 +471,16 @@ zpool_open_func(void *arg)
 	    &num_labels)) != 0) {
 		CloseHandle(fd);
 		(void) no_memory(rn->rn_hdl);
+		TraceEvent(TRACE_INFO, "func return.zpool_read_label_win failed. ThreadID:%lu", threadID);
 		return;
 	}
 
+	TraceEvent(TRACE_INFO,"num_labels %d ThreadID:%lu", num_labels, threadID);
 	if (num_labels == 0) {
 		CloseHandle(fd);
+		TraceEvent(TRACE_INFO,"Freeing nvlist. num_labels=0 ThreadID:%lu", threadID);
 		nvlist_free(config);
+		TraceEvent(TRACE_INFO,"func return.num_labels=0 ThreadID:%lu", threadID);
 		return;
 	}
 
@@ -476,6 +502,7 @@ zpool_open_func(void *arg)
 	rn->rn_config = config;
 	rn->rn_num_labels = num_labels;
 
+	TraceEvent(TRACE_INFO, "rn->rn_labelpaths %d", rn->rn_labelpaths);
 	/*
 	 * Add additional entries for paths described by this label.
 	 */
@@ -669,6 +696,7 @@ int
 zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
     avl_tree_t **slice_cache)
 {
+	TraceEvent(TRACE_INFO,"zpool_find_import_blkid function started");
 	int i, dirs;
 	struct dirent *dp;
 	char path[MAXPATHLEN];
@@ -715,7 +743,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 	ZeroMemory(&deviceInterfaceData, sizeof (SP_DEVICE_INTERFACE_DATA));
 	deviceInterfaceData.cbSize = sizeof (SP_DEVICE_INTERFACE_DATA);
 	deviceIndex = 0;
-
+	TraceEvent(TRACE_INFO, "Before enumerating the devices");
 	while (SetupDiEnumDeviceInterfaces(diskClassDevices,
 	    NULL,
 	    &diskClassDeviceInterfaceGuid,
@@ -781,7 +809,8 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 		fflush(stderr);
 		snprintf(rdsk, MAXPATHLEN, "\\\\.\\PHYSICALDRIVE%d",
 		    diskNumber.DeviceNumber);
-
+		TraceEvent(TRACE_INFO,"path '%s' and '\\\\?\\PhysicalDrive%d' rdsk %s :", deviceInterfaceDetailData->DevicePath,
+		    diskNumber.DeviceNumber, rdsk);
 		// CloseHandle(disk);
 
 #if 0
@@ -804,6 +833,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 			    partitions->PartitionCount);
 			fflush(stderr);
 
+			TraceEvent(TRACE_INFO," Partion count :%d", partitions->PartitionCount);
 			for (int i = 0; i < partitions->PartitionCount; i++) {
 				int add = 0;
 		switch (partitions->PartitionEntry[i].PartitionStyle) {
@@ -815,6 +845,10 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 			    StartingOffset.QuadPart,
 			    partitions->PartitionEntry[i].
 			    PartitionLength.QuadPart);
+			TraceEvent(TRACE_INFO,"mbr %d: type %x off 0x%llx len 0x%llx", i,
+			    partitions->PartitionEntry[i].Mbr.PartitionType,
+			    partitions->PartitionEntry[i].StartingOffset.QuadPart,
+			    partitions->PartitionEntry[i].PartitionLength.QuadPart);
 			fflush(stderr);
 			add = 1;
 			break;
@@ -826,6 +860,9 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 			    StartingOffset.QuadPart,
 			    partitions->PartitionEntry[i].PartitionLength.
 			    QuadPart);
+			TraceEvent(TRACE_INFO,"gpt %d: off 0x%llx len 0x%llx", i,
+			    partitions->PartitionEntry[i].StartingOffset.QuadPart,
+			    partitions->PartitionEntry[i].PartitionLength.QuadPart);
 			fflush(stderr);
 			add = 1;
 			break;
@@ -874,7 +911,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 				    "#%llu#%llu#%s",
 				    0ULL, size,
 				    deviceInterfaceDetailData->DevicePath);
-
+				TraceEvent(TRACE_INFO,"diskname::::%s errorcode:%d", slice->rn_name, error);
 				if (error == -1) {
 					free(slice);
 					continue;
@@ -901,6 +938,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 			free(partitions);
 		} else {
 			fprintf(stderr, "read partitions ng\n");
+			TraceEvent(TRACE_INFO,"read partitions ng");
 			fflush(stderr);
 		}
 
@@ -923,6 +961,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 		// 0x8410 "version" "name" "testpool" ZFS label
 		if (disk != INVALID_HANDLE_VALUE) {
 			fprintf(stderr, "asking libefi to read label\n");
+			TraceEvent(TRACE_INFO,"asking libefi to read label");
 			fflush(stderr);
 			int error;
 			struct dk_gpt *vtoc;
@@ -931,6 +970,7 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 				fprintf(stderr,
 				    "EFI read OK, max partitions %d\n",
 				    vtoc->efi_nparts);
+				TraceEvent(TRACE_INFO,"EFI read OK, max partitions %d", vtoc->efi_nparts);
 				fflush(stderr);
 				for (int i = 0; i < vtoc->efi_nparts; i++) {
 
@@ -942,6 +982,11 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 			    "    part %d:  offset %llx:    len %llx:    "
 			    "tag: %x    name: '%s'\n",
 			    i, vtoc->efi_parts[i].p_start,
+			    vtoc->efi_parts[i].p_size,
+			    vtoc->efi_parts[i].p_tag,
+			    vtoc->efi_parts[i].p_name);
+			TraceEvent(TRACE_INFO,"part %d:  offset %llx:    len %llx:    "
+			    "tag: %x    name: '%s' ", i, vtoc->efi_parts[i].p_start,
 			    vtoc->efi_parts[i].p_size,
 			    vtoc->efi_parts[i].p_tag,
 			    vtoc->efi_parts[i].p_name);
@@ -986,6 +1031,9 @@ zpool_find_import_blkid(libpc_handle_t *hdl, pthread_mutex_t *lock,
 		} else { // Unable to open handle
 			fprintf(stderr,
 			    "Unable to open disk, are we Administrator? "
+			    "GetLastError() is 0x%x\n",
+			    GetLastError());
+			TraceEvent(TRACE_INFO,"Unable to open disk, are we Administrator ? "
 			    "GetLastError() is 0x%x\n",
 			    GetLastError());
 			fflush(stderr);
@@ -1203,6 +1251,7 @@ update_vdev_config_dev_strs(nvlist_t *nv)
 		fflush(stderr);
 		fprintf(stderr, "setting physpath here '%s'\r\n", path);
 		fflush(stderr);
+		TraceEvent(TRACE_INFO, "setting path here '%s'\r\n", vdev_path);
 		if (nvlist_add_string(nv, ZPOOL_CONFIG_PHYS_PATH, path) != 0)
 			return;
 		// This call frees the original path.

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -68,6 +68,7 @@
 #include <libnvpair.h>
 
 #include "zutil_import.h"
+#include "os/windows/Trace.h"
 
 /*PRINTFLIKE2*/
 static void
@@ -466,6 +467,7 @@ static nvlist_t *
 get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
     nvlist_t *policy)
 {
+	TraceEvent(TRACE_INFO,"get_configs function started");
 	pool_entry_t *pe;
 	vdev_entry_t *ve;
 	config_entry_t *ce;
@@ -501,6 +503,7 @@ get_configs(libpc_handle_t *hdl, pool_list_t *pl, boolean_t active_ok,
 		 * from the first one we find, and then go through the rest and
 		 * add them as necessary to the 'vdevs' member of the config.
 		 */
+		TraceEvent(TRACE_INFO,"Going to iterate the Vdevs");
 		for (ve = pe->pe_vdevs; ve != NULL; ve = ve->ve_next) {
 
 			/*
@@ -1411,13 +1414,16 @@ zpool_find_import_impl(libpc_handle_t *hdl, importargs_t *iarg,
 	 * validating labels, a large number of threads can be used due to
 	 * minimal contention.
 	 */
+	TraceEvent(TRACE_INFO,"num of entries in slice_cache:%d.", &cache->avl_numnodes);
 	t = tpool_create(1, 2 * sysconf(_SC_NPROCESSORS_ONLN), 0, NULL);
 	for (slice = avl_first(cache); slice;
 	    (slice = avl_walk(cache, slice, AVL_AFTER)))
 		(void) tpool_dispatch(t, zpool_open_func, slice);
-
+	TraceEvent(TRACE_INFO,"Main thread going to wait for tpool thread to complete all zpool_open_func");
 	tpool_wait(t);
+	TraceEvent(TRACE_INFO,"Main thread going to wait for tpool destroy() to complete");
 	tpool_destroy(t);
+	TraceEvent(TRACE_INFO,"Main thread.All tpool zpool_open_func operation completed");
 
 	/*
 	 * Process the cache, filtering out any entries which are not
@@ -1507,7 +1513,7 @@ zpool_find_import_impl(libpc_handle_t *hdl, importargs_t *iarg,
 		free(ne->ne_name);
 		free(ne);
 	}
-
+	TraceEvent(TRACE_INFO, "zpool_find_import_impl function returns");
 	return (ret);
 }
 
@@ -1770,6 +1776,7 @@ nvlist_t *
 zpool_search_import(void *hdl, importargs_t *import,
     const pool_config_ops_t *pco)
 {
+	TraceEvent(TRACE_INFO,"zpool_search_import function called");
 	libpc_handle_t handle = { 0 };
 	nvlist_t *pools = NULL;
 


### PR DESCRIPTION
### Motivation and Context
There is no logging in userland to debug. So implemented the WPP tracing for Zpool executable


### Description
Added WPP tracing for zpool executable. done changes in makefile to generate .tmh file for zpool executable related files.

### How Has This Been Tested?
Tested manaually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
