### PR TITLE
Do not bug check when any WMI method is not implemented.

### DIFF
--- a/module/os/windows/zfs/zfs_windows_zvol_wmi.c
+++ b/module/os/windows/zfs/zfs_windows_zvol_wmi.c
@@ -762,13 +762,6 @@ ExecuteWmiMethod(
 		}
 
 				default:
-
-					__try {
-						DbgBreakPoint();
-					}
-					__except(EXCEPTION_EXECUTE_HANDLER) {
-					}
-
 					status = SRB_STATUS_INVALID_REQUEST;
 					break;
 			}
@@ -1036,12 +1029,6 @@ ExecuteWmiMethod(
 	}
 
 	default:
-		__try {
-			DbgBreakPoint();
-		}
-		__except(EXCEPTION_EXECUTE_HANDLER) {
-		}
-
 		status = SRB_STATUS_INVALID_REQUEST;
 		break;
 		}


### PR DESCRIPTION
**Jira**: [SSV-22607]: BSOD: SYSTEM_SERVICE_EXCEPTION (3b): ZFSin!ExecuteWmiMethod+222

**Issue**: Bug check when some WMI methods are not implemented and DbgBreakPoint() is executed.

In zfsin(compiled with VS), DbgBreakPoint() is replaced by __debugbreak and it does not bugcheck.

_file: wdm.h
#if (_MSC_FULL_VER >= 150030729) && !defined(IMPORT_NATIVE_DBG_BREAK)
#define DbgBreakPoint __debugbreak
#else
__analysis_noreturn
VOID
NTAPI
DbgBreakPoint(
VOID
);_

But with openzfs/clang, it is compiled to DbgBreakPoint() function which bugchecks.

**Fix**: Reported the issue to openzfs community and they approved the fix.
https://github.com/openzfsonwindows/openzfs/issues/243
Remove DbgBreakPoint() from the WMI methods.

**Tested**:- Using the powershell commandline.
_$portWWN = "3456789A"
[byte[]]$portWWNArr = $portWWN.ToCharArray()

Get-WMIObject -Class MSFC_HBAAdapterMethods -Namespace root\wmi | ForEach-Object {$_.GetFC4Statistics($portWWNArr,8)}

Get-WMIObject -Class MSFC_HBAFCPInfo -Namespace root\wmi| ForEach-Object {$_.GetBindingCapability($portWWNArr)}_


[SSV-22607]: https://dcsw.atlassian.net/browse/SSV-22607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ