### PR TITLE
 SSV-22900: Return the usable spa dspace in the performance metrics ioctl

### DIFF
--- a/module/os/windows/zfs/zfs_ioctl_os.c
+++ b/module/os/windows/zfs/zfs_ioctl_os.c
@@ -90,6 +90,31 @@ zfs_vfs_ref(zfsvfs_t **zfvp)
 	return (error);
 }
 
+/*
+ * Returns the actual usable pool size adjusting the slop space which
+ * is same as reported by "zfs list" cmd.
+ *
+ * See the comment above spa_get_slop_space() for more details.
+ */
+static uint64_t
+spa_get_usable_dspace(spa_t *spa)
+{
+	uint64_t poolsize = 0;
+
+	if (spa != NULL) {
+		uint64_t space = metaslab_class_get_dspace(spa_normal_class(spa));
+		uint64_t resv = spa_get_slop_space(spa);
+
+		poolsize = (space >= resv) ? (space - resv) : 0;
+
+		TraceEvent(TRACE_VERBOSE,
+		    "%s:%d: total_dspace: %llu, slop_space: %llu, poolsize: %llu, spa_dedup_dspace: %llu\n",
+		    __func__, __LINE__, space, resv, poolsize, spa->spa_dedup_dspace);
+	}
+
+	return (poolsize);
+}
+
 extern kstat_t* perf_arc_ksp;
 extern uint64_t getL2ArcAllocSize(arc_stats_t* arc_ptr);
 NTSTATUS zpool_zfs_get_metrics(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_LOCATION IrpSp)
@@ -150,13 +175,17 @@ NTSTATUS zpool_zfs_get_metrics(PDEVICE_OBJECT DeviceObject, PIRP Irp, PIO_STACK_
 	vdev_get_stats(spa_perf->spa_root_vdev, &vs);
 	perf->zpool_dedup_ratio = ddt_get_pool_dedup_ratio(spa_perf);
 	const char* healthState = spa_state_to_name(spa_perf);
+
+	// SSV-22900: get the actual usable spa pool size.
+	uint64_t pool_size = spa_get_usable_dspace(spa_perf);
+	uint64_t pool_alloc = (pool_size >= perf->available) ? (pool_size - perf->available) : 0;
+
 	spa_config_exit(spa_perf, SCL_ALL, FTAG);
 	mutex_exit(&spa_namespace_lock);
 
-	perf->zpool_allocated = vs.vs_alloc;
-	perf->zpool_size = vs.vs_space;
+	perf->zpool_allocated = pool_alloc;
+	perf->zpool_size = pool_size;
 	strcpy(perf->zpoolHealthState, healthState);
-
     }
     else
 	perf->zfs_volSize = getZvolSize(perf->name);

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -503,7 +503,7 @@ ddt_get_dedup_histogram(spa_t *spa, ddt_histogram_t *ddh)
 {
 	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
-		for (enum ddt_type type = 0; type < DDT_TYPES; type++) {
+		for (enum ddt_type type = 0; type < DDT_TYPES && ddt; type++) {
 			for (enum ddt_class class = 0; class < DDT_CLASSES;
 			    class++) {
 				ddt_histogram_add(ddh,

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1802,8 +1802,22 @@ spa_get_worst_case_asize(spa_t *spa, uint64_t lsize)
 uint64_t
 spa_get_slop_space(spa_t *spa)
 {
-	uint64_t space = spa_get_dspace(spa);
-	uint64_t slop = MIN(space >> spa_slop_shift, spa_max_slop);
+	uint64_t space = 0;
+	uint64_t slop = 0;
+
+	/*
+	 * Make sure spa_dedup_dspace has been set.
+	 */
+	if (spa->spa_dedup_dspace == ~0ULL)
+		spa_update_dspace(spa);
+
+	/*
+	 * spa_get_dspace() includes the space only logically "used" by
+	 * deduplicated data, so since it's not useful to reserve more
+	 * space with more deduplicated data, we subtract that out here.
+	 */
+	space = spa_get_dspace(spa) - spa->spa_dedup_dspace;
+	slop = MIN(space >> spa_slop_shift, spa_max_slop);
 
 	/*
 	 * Subtract the embedded log space, but no more than half the (3.2%)


### PR DESCRIPTION
**Jira**: SSV-22900: CO available space in Disk pool is showing wrong value.

**Issue**: In the case of raidz1, the DMC was showing the total size of all the raidz1 disks and special mirror vdev and not the actual usable capacity.

**Fix:** Get the dspace(deflated space) from the spa normal metaslab class and subtract the slop reservation space to get the actual usable pool size.
The commit 7d275c68476c55cbfdb0b32c5039165ce90c1a1d (Tinker with slop space accounting with dedup) is a prerequisite commit that was down streamed. Without this commit, more slop space was reserved when deduplication data was present and it was showing lesser available space.

**Tests by Dev: -**
1) Tested on both RAID0 and RAID5 to validate that correct zpool sizes and alloc and available details are reported in DMC.
2) QA also testing in parallel, and results will be updated in https://dcsw.atlassian.net/browse/SSV-22930
3) ZFS test suite does not exercise the perf metric ioctl. Ran the unit test against ZFS build 15.0.1700.80 and all the tests passed.
_http://10.200.2.48:8080/job/OpenZFS-Test-Suite/115/console_ 

**Tests to be done by QA: _**
1) Run DCAF test suite.
2) Manual testing.