### PR TITLE
SSV-22933: Do not include special mirror vdev size in ZPOOL_GET_SIZE_STATS ioctl response.

### DIFF
--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -1066,13 +1066,9 @@ fetch_zpool_stats(zpool_size_stats *zstats) {
 
 		zstats->alloc = metaslab_class_get_alloc(mc);
 		zstats->alloc +=
-		    metaslab_class_get_alloc(spa_special_class(spa));
-		zstats->alloc +=
 		    metaslab_class_get_alloc(spa_dedup_class(spa));
 
 		zstats->size = metaslab_class_get_space(mc);
-		zstats->size +=
-		    metaslab_class_get_space(spa_special_class(spa));
 		zstats->size += metaslab_class_get_space(spa_dedup_class(spa));
 		mutex_exit(&spa->spa_props_lock);
 		ret = 0;


### PR DESCRIPTION
**Jira**: SSV-22933 : zpool allocations exceed 85% when CO is configured with special mirror vdev

**Issue**: Special mirror vdev size/alloc is included in the zpool size reported to the pool driver in the ZPOOL_GET_SIZE_STATS ioctl response. This results in pool driver exceeding the 85% zpool allocation thresh hold. 

**Fix**: Since special vdev is used only to store metadata, it's size should not be included. 

**Tests by Dev**: -
Tested on both RAID0 and RAID5 with/without special mirror vdev to validate that correct zpool sizes and alloc details are reported in the ioctl response. Zpool allocations did not exceed thresh hold of ~85%.

**Tests to be done by QA:** 
1) Add the new low space test cases with special mirror vdev in the ILDC DCAF test suite.
2) Manual testing.