### PR TITLE
SSV-22797: Check free thread is running before trying to set memory pressure. (#338)

### DIFF
--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -71,7 +71,8 @@ const unsigned int spl_vm_page_free_min = 3500;
 static kcondvar_t spl_free_thread_cv;
 static kmutex_t spl_free_thread_lock;
 static boolean_t spl_free_thread_exit;
-static volatile _Atomic int64_t spl_free;
+volatile boolean_t spl_free_thread_running = FALSE;
+static volatile _Atomic int64_t spl_free = 0;
 int64_t spl_free_delta_ema;
 
 static boolean_t spl_event_thread_exit = FALSE;
@@ -5339,6 +5340,7 @@ spl_kmem_thread_init(void)
 	spl_free_thread_exit = FALSE;
 	(void) cv_init(&spl_free_thread_cv, NULL, CV_DEFAULT, NULL);
 	(void) thread_create(NULL, 0, spl_free_thread, 0, 0, 0, 0, 92);
+	spl_free_thread_running = TRUE;
 
 	spl_event_thread_exit = FALSE;
 	(void) thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);
@@ -5365,6 +5367,7 @@ spl_kmem_thread_fini(void)
 		cv_signal(&spl_free_thread_cv);
 		cv_wait(&spl_free_thread_cv, &spl_free_thread_lock);
 	}
+	spl_free_thread_running = FALSE;
 	mutex_exit(&spl_free_thread_lock);
 	cv_destroy(&spl_free_thread_cv);
 	mutex_destroy(&spl_free_thread_lock);

--- a/module/os/windows/spl/spl-vmem.c
+++ b/module/os/windows/spl/spl-vmem.c
@@ -1615,35 +1615,51 @@ do_alloc:
 		mutex_enter(&vmp->vm_lock);
 		if (vmflag & VM_NOSLEEP)
 			break;
-		atomic_inc_64(&vmp->vm_kstat.vk_wait.value.ui64);
-		atomic_inc_64(&vmp->vm_kstat.vk_threads_waiting.value.ui64);
-		atomic_inc_64(&spl_vmem_threads_waiting);
-		if (spl_vmem_threads_waiting > 0) {
-			dprintf("SPL: %s: vmem waiting for %lu sized alloc "
-			    "for %s, waiting threads %llu, total threads "
-			    "waiting = %llu\n",
-			    __func__, size, vmp->vm_name,
-			    vmp->vm_kstat.vk_threads_waiting.value.ui64,
-			    spl_vmem_threads_waiting);
-			extern int64_t spl_free_set_and_wait_pressure(int64_t,
-			    boolean_t, clock_t);
-			extern int64_t spl_free_manual_pressure_wrapper(void);
-			mutex_exit(&vmp->vm_lock);
-			// release other waiting threads
-			spl_free_set_pressure(0);
-			int64_t target_pressure = size *
-			    spl_vmem_threads_waiting;
-			int64_t delivered_pressure =
-			    spl_free_set_and_wait_pressure(target_pressure,
-			    TRUE, USEC2NSEC(500));
-			dprintf("SPL: %s: pressure %lld targeted, %lld "
-			    "delivered\n", __func__, target_pressure,
-			    delivered_pressure);
-			mutex_enter(&vmp->vm_lock);
+
+		extern volatile boolean_t spl_free_thread_running;
+
+		if (spl_free_thread_running) {
+			atomic_inc_64(&vmp->vm_kstat.vk_wait.value.ui64);
+			atomic_inc_64(
+			    &vmp->vm_kstat.vk_threads_waiting.value.ui64);
+			atomic_inc_64(&spl_vmem_threads_waiting);
+			if (spl_vmem_threads_waiting > 0) {
+				dprintf("SPL: %s: vmem waiting for %lu sized "
+				    "alloc for %s, waiting threads %llu, total "
+				    "threads waiting = %llu\n",
+				    __func__, size, vmp->vm_name,
+				    vmp->vm_kstat.vk_threads_waiting.value.ui64,
+				    spl_vmem_threads_waiting);
+				extern int64_t spl_free_set_and_wait_pressure(
+				    int64_t, boolean_t, clock_t);
+				extern int64_t spl_free_manual_pressure_wrapper(
+				    void);
+				mutex_exit(&vmp->vm_lock);
+				// release other waiting threads
+				spl_free_set_pressure(0);
+				int64_t target_pressure = size *
+				    spl_vmem_threads_waiting;
+				int64_t delivered_pressure =
+				    spl_free_set_and_wait_pressure(
+				    target_pressure, TRUE,
+				    USEC2NSEC(500));
+				dprintf("SPL: %s: pressure %lld targeted, %lld "
+				    "delivered\n", __func__, target_pressure,
+				    delivered_pressure);
+				mutex_enter(&vmp->vm_lock);
+			}
+			cv_wait(&vmp->vm_cv, &vmp->vm_lock);
+			atomic_dec_64(&spl_vmem_threads_waiting);
+			atomic_dec_64(
+			    &vmp->vm_kstat.vk_threads_waiting.value.ui64);
 		}
-		cv_wait(&vmp->vm_cv, &vmp->vm_lock);
-		atomic_dec_64(&spl_vmem_threads_waiting);
-		atomic_dec_64(&vmp->vm_kstat.vk_threads_waiting.value.ui64);
+		else
+		{
+			DbgPrintEx(DPFLTR_IHVDRIVER_ID, DPFLTR_INFO_LEVEL,
+			    "SPL: %s: Not able to set pressure %lld as free"
+			    "thread is not running\n", __func__, size);
+			delay(hz);
+		}
 	}
 	if (vbest != NULL) {
 		ASSERT(vbest->vs_type == VMEM_FREE);


### PR DESCRIPTION
**Jira:** 
SSV-22797: Installation of PSP16 upgrade triggers unexpected BSOD/reboot related to ZFS

**Cause**: 
The Panic was during ZFS driver install/initialize on a VM in Hyper-V. During initialization, new memory allocation failed and then while trying to set the memory pressure, the condition variable spl_free_thread_cv was attempted to be used (which was not yet initialized) and this caused panic.

**Fix:**
Downstream the PR https://github.com/openzfsonwindows/openzfs/pull/338.
 Checking free thread is running before trying to set the memory pressure.

**Test**: 
1) Executed ZFS unit test which exercises both the install and memory allocations and all tests passed
http://10.200.2.48:8080/job/OpenZFS-Test-Suite/116

2) Executed the DCAF ILDC test suites in CI and it passed.

**QA**: Run DCAF ILDC automation.