### PR TITLE
SSV-24185: Fix the number of zvol I/O threads to align with 50% of the maximum available logical CPUs.

### DIFF
--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -149,6 +149,7 @@ typedef struct windows_kstat {
 	kstat_named_t zfs_total_memory_limit;
 	kstat_named_t zfs_removal_suspend_progress;
 	kstat_named_t cpu_avx_supported;
+	kstat_named_t zvol_io_threads;
 } windows_kstat_t;
 
 
@@ -259,6 +260,7 @@ extern uint64_t zfs_initialize_value;
 extern int zfs_autoimport_disable;
 extern int zfs_removal_suspend_progress;
 extern int cpu_avx_supported;
+extern int zvol_io_threads;
 
 int  kstat_windows_init(void *);
 void kstat_windows_fini(void);

--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -260,7 +260,7 @@ extern uint64_t zfs_initialize_value;
 extern int zfs_autoimport_disable;
 extern int zfs_removal_suspend_progress;
 extern int cpu_avx_supported;
-extern int zvol_io_threads;
+extern int zvol_threads;
 
 int  kstat_windows_init(void *);
 void kstat_windows_fini(void);

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -695,8 +695,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		zfs_arc_p_min_shift = ks->arc_zfs_arc_p_min_shift.value.ui64;
 		zfs_arc_average_blocksize =
 		    ks->arc_zfs_arc_average_blocksize.value.ui64;
-		zvol_io_threads =
-		    ks->zvol_io_threads.value.ui32;
+		zvol_threads = ks->zvol_io_threads.value.ui32;
 
 #ifdef _KERNEL
 		if (ks->zfs_total_memory_limit.value.ui64 > total_memory &&
@@ -731,7 +730,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		ks->arc_zfs_arc_p_min_shift.value.ui64 = zfs_arc_p_min_shift;
 		ks->arc_zfs_arc_average_blocksize.value.ui64 =
 		    zfs_arc_average_blocksize;
-		ks->zvol_io_threads.value.ui32 = zvol_io_threads;
+		ks->zvol_io_threads.value.ui32 = zvol_threads;
 
 #ifdef _KERNEL
 		ks->zfs_total_memory_limit.value.ui64 = total_memory;

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -695,6 +695,8 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		zfs_arc_p_min_shift = ks->arc_zfs_arc_p_min_shift.value.ui64;
 		zfs_arc_average_blocksize =
 		    ks->arc_zfs_arc_average_blocksize.value.ui64;
+		zvol_io_threads =
+		    ks->zvol_io_threads.value.ui32;
 
 #ifdef _KERNEL
 		if (ks->zfs_total_memory_limit.value.ui64 > total_memory &&
@@ -729,6 +731,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		ks->arc_zfs_arc_p_min_shift.value.ui64 = zfs_arc_p_min_shift;
 		ks->arc_zfs_arc_average_blocksize.value.ui64 =
 		    zfs_arc_average_blocksize;
+		ks->zvol_io_threads.value.ui32 = zvol_io_threads;
 
 #ifdef _KERNEL
 		ks->zfs_total_memory_limit.value.ui64 = total_memory;

--- a/module/os/windows/zfs/zfs_kstat_windows.c
+++ b/module/os/windows/zfs/zfs_kstat_windows.c
@@ -383,9 +383,6 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->zfs_removal_suspend_progress.value.i32;
 		cpu_avx_supported =
 		    ks->cpu_avx_supported.value.ui32;
-		zvol_io_threads =
-		    ks->zvol_io_threads.value.ui32;
-
 	} else {
 
 		/* kstat READ */
@@ -575,7 +572,7 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		ks->cpu_avx_supported.value.ui32 =
 		    cpu_avx_supported;
 		ks->zvol_io_threads.value.ui32 =
-		    zvol_io_threads;
+		    zvol_threads;
 	}
 	arc_kstat_update_windows(ksp, rw);
 	return (0);

--- a/module/os/windows/zfs/zfs_kstat_windows.c
+++ b/module/os/windows/zfs/zfs_kstat_windows.c
@@ -172,7 +172,8 @@ windows_kstat_t windows_kstat = {
 	{ "zfs_autoimport_disable",		KSTAT_DATA_UINT64 },
 	{ "zfs_total_memory_limit",		KSTAT_DATA_UINT64 },
 	{ "zfs_removal_suspend_progress",	KSTAT_DATA_INT32 },
-	{ "cpu_avx_supported",			KSTAT_DATA_UINT32 }
+	{ "cpu_avx_supported",			KSTAT_DATA_UINT32 },
+	{ "zvol_io_threads",			KSTAT_DATA_UINT32 }
 };
 
 
@@ -382,6 +383,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->zfs_removal_suspend_progress.value.i32;
 		cpu_avx_supported =
 		    ks->cpu_avx_supported.value.ui32;
+		zvol_io_threads =
+		    ks->zvol_io_threads.value.ui32;
 
 	} else {
 
@@ -571,6 +574,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    zfs_removal_suspend_progress;
 		ks->cpu_avx_supported.value.ui32 =
 		    cpu_avx_supported;
+		ks->zvol_io_threads.value.ui32 =
+		    zvol_io_threads;
 	}
 	arc_kstat_update_windows(ksp, rw);
 	return (0);

--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -45,8 +45,7 @@ static uint32_t zvol_major = ZVOL_MAJOR;
 unsigned int zvol_request_sync = 0;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
-unsigned int zvol_threads = 32;
-int zvol_io_threads = 0;
+int zvol_threads = 0;
 
 taskq_t *zvol_taskq;
 
@@ -1029,20 +1028,20 @@ const static zvol_platform_ops_t zvol_windows_ops = {
 int
 zvol_init(void)
 {
-	if (!zvol_io_threads)
-		zvol_io_threads = zvol_threads;
+	int logical_ncpu_to_use = boot_ncpus / 2; // boot_ncpus is derived from KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS)
 
-	zvol_threads = zvol_io_threads;
-
-	int threads = MIN(MAX(zvol_threads, 1), 1024);
+	int threads = MIN(MAX((zvol_threads ? zvol_threads: logical_ncpu_to_use), 1), 1024);
 
 	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
-		"%s: zvol taskq threads %d regvalue: %d\n", __func__, threads, zvol_io_threads));
+		"%s: number of zvol taskq threads to be created: %d, registry value: %d ncpus: %d\n",
+		__func__, threads, zvol_threads, boot_ncpus));
 	zvol_taskq = taskq_create(ZVOL_DRIVER, threads, maxclsyspri,
 	    threads * 2, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 	if (zvol_taskq == NULL) {
 		return (-ENOMEM);
 	}
+
+	zvol_threads = threads; // Update it so that kstat gets the current value
 
 	zvol_init_impl();
 	zvol_register_ops(&zvol_windows_ops);

--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -46,6 +46,7 @@ unsigned int zvol_request_sync = 0;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
 unsigned int zvol_threads = 32;
+int zvol_io_threads = 0;
 
 taskq_t *zvol_taskq;
 
@@ -1028,8 +1029,15 @@ const static zvol_platform_ops_t zvol_windows_ops = {
 int
 zvol_init(void)
 {
+	if (!zvol_io_threads)
+		zvol_io_threads = zvol_threads;
+
+	zvol_threads = zvol_io_threads;
+
 	int threads = MIN(MAX(zvol_threads, 1), 1024);
 
+	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
+		"%s: zvol taskq threads %d regvalue: %d\n", __func__, threads, zvol_io_threads));
 	zvol_taskq = taskq_create(ZVOL_DRIVER, threads, maxclsyspri,
 	    threads * 2, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 	if (zvol_taskq == NULL) {

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -1461,8 +1461,8 @@ dbuf_read_verify_dnode_crypt(dmu_buf_impl_t *db, uint32_t flags)
 
 	DB_DNODE_EXIT(db);
 
-	TraceEvent(err > 0 ? 2:8, "%s:%d: Returning %d\n",
-	    __func__, __LINE__, err);
+//	TraceEvent(err > 0 ? 2:8, "%s:%d: Returning %d\n",
+//	    __func__, __LINE__, err);
 
 	return (err);
 }
@@ -1565,8 +1565,8 @@ early_unlock:
 	mutex_exit(&db->db_mtx);
 	dmu_buf_unlock_parent(db, dblt, tag);
 
-	TraceEvent(err > 0 ? 2 : 8, "%s:%d: Returning %d\n",
-	    __func__, __LINE__, err);
+	//TraceEvent(err > 0 ? 2 : 8, "%s:%d: Returning %d\n",
+	 //   __func__, __LINE__, err);
 
 	return (err);
 }

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -437,8 +437,8 @@ error:
 		rw_exit(&spa->spa_keystore.sk_wkeys_lock);
 
 	*wkey_out = NULL;
-	TraceEvent(ret > 0 ? 2 : 8, "%s:%d: Returning %d\n",
-	    __func__, __LINE__, ret);
+	//TraceEvent(ret > 0 ? 2 : 8, "%s:%d: Returning %d\n",
+	//    __func__, __LINE__, ret);
 
 	return (ret);
 }

--- a/module/zfs/space_map.c
+++ b/module/zfs/space_map.c
@@ -191,8 +191,8 @@ space_map_iterate(space_map_t *sm, uint64_t end, sm_cb_t callback, void *arg)
 		dmu_buf_rele(db, FTAG);
 	}
 
-	TraceEvent(error > 0 ? 2 : 8, "%s:%d: Returning %d\n",
-	    __func__, __LINE__, error);
+	//TraceEvent(error > 0 ? 2 : 8, "%s:%d: Returning %d\n",
+	//    __func__, __LINE__, error);
 	return (error);
 }
 

--- a/module/zfs/zap.c
+++ b/module/zfs/zap.c
@@ -640,8 +640,8 @@ zap_deref_leaf(zap_t *zap, uint64_t h, dmu_tx_t *tx, krw_t lt, zap_leaf_t **lp)
 	    ZAP_HASH_IDX(h, zap_leaf_phys(*lp)->l_hdr.lh_prefix_len) ==
 	    zap_leaf_phys(*lp)->l_hdr.lh_prefix);
 
-	TraceEvent(err > 0 ? 2 : 8, "%s:%d: Returning %d\n",
-	    __func__, __LINE__, err);
+//	TraceEvent(err > 0 ? 2 : 8, "%s:%d: Returning %d\n",
+//	    __func__, __LINE__, err);
 	return (err);
 }
 

--- a/module/zfs/zap_micro.c
+++ b/module/zfs/zap_micro.c
@@ -611,8 +611,8 @@ zap_lockdir_by_dnode(dnode_t *dn, dmu_tx_t *tx,
 		dmu_buf_rele(db, tag);
 	}
 
-	TraceEvent(err > 0 ? 2 : 8, "%s:%d: Returning %d\n",
-	    __func__, __LINE__, err);
+	//TraceEvent(err > 0 ? 2 : 8, "%s:%d: Returning %d\n",
+	//    __func__, __LINE__, err);
 	return (err);
 }
 

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -7494,8 +7494,8 @@ pool_status_check(const char *name, zfs_ioc_namecheck_t type,
 		spa_close(spa, FTAG);
 	}
 
-	TraceEvent(error > 0 ? 2 : 8, "%s:%d: Returning with error %d\n",
-	    __func__, __LINE__, error);
+	//TraceEvent(error > 0 ? 2 : 8, "%s:%d: Returning with error %d\n",
+	//    __func__, __LINE__, error);
 	return (error);
 }
 


### PR DESCRIPTION
SSV-24185

Issue: CPU stuck at 100% is related to ZFS when we use dedup & comp, never able to reproduce the issue with Compression only enable.

Fix: The number of zvol I/O threads to align with 50% of the maximum available logical CPUs if the 'zvol_io_threads' value in 'Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ZFSin' is not specified. If the 'zvol_io_threads' value is provided, use this value for creating the zvol task queue thread pool.

Use kstat.exe zfs:0:tunable to check the current value of zvol_io_threads. This can be set only by updating the registry, and also require a reboot.