### PR TITLE
SSV-24782:Create MSVC-specific wrapper library for reading CR8 register

### DIFF
--- a/module/icp/CMakeLists.txt
+++ b/module/icp/CMakeLists.txt
@@ -53,5 +53,5 @@ wdk_add_library(icpkern
   spi/kcf_spi.c
 )
 
-target_link_libraries(icpkern PRIVATE splkern PUBLIC ${ISAL})
+target_link_libraries(icpkern PRIVATE splkern spl_cr_wrappers PUBLIC ${ISAL})
 target_include_directories(icpkern BEFORE PUBLIC "include")

--- a/module/icp/CMakeLists.txt
+++ b/module/icp/CMakeLists.txt
@@ -53,5 +53,5 @@ wdk_add_library(icpkern
   spi/kcf_spi.c
 )
 
-target_link_libraries(icpkern PRIVATE splkern spl_cr_wrappers PUBLIC ${ISAL})
+target_link_libraries(icpkern PRIVATE splkern PUBLIC ${ISAL})
 target_include_directories(icpkern BEFORE PUBLIC "include")

--- a/module/os/windows/spl/CMakeLists.txt
+++ b/module/os/windows/spl/CMakeLists.txt
@@ -40,6 +40,40 @@ wdk_add_library(splkern
   ${TMH_FILE_LIST}
 )
 
+target_include_directories(splkern BEFORE PUBLIC "${CMAKE_SOURCE_DIR}/include/os/windows/" PUBLIC "${CMAKE_SOURCE_DIR}/include/os/windows/spl")
 # set(CMAKE_TOOLCHAIN_FILE $ENV{CMAKE_TOOLCHAIN_FILE})
 
-target_include_directories(splkern BEFORE PUBLIC "${CMAKE_SOURCE_DIR}/include/os/windows/" PUBLIC "${CMAKE_SOURCE_DIR}/include/os/windows/spl")
+find_program(MSVC_CL_EXECUTABLE cl.exe)
+if(NOT MSVC_CL_EXECUTABLE)
+    message(FATAL_ERROR "MSVC_CL_EXECUTABLE is not set! Make sure to run CMake with a configured compiler.")
+else()
+    message(STATUS "MSVC_CL_EXECUTABLE is set to: ${MSVC_CL_EXECUTABLE}")
+endif()
+
+find_program(MSVC_LIB_EXECUTABLE lib.exe)
+if(NOT MSVC_LIB_EXECUTABLE)
+    message(FATAL_ERROR "MSVC lib.exe not found in PATH. Ensure you're using Visual Studio Command Prompt or MSVC toolchain.")
+else()
+message(STATUS "MSVC_LIB_EXECUTABLE is set to: ${MSVC_LIB_EXECUTABLE}")
+endif()
+
+set(CR_WRAPPERS_DIR "${CMAKE_BINARY_DIR}/module/os/windows/spl")
+file(MAKE_DIRECTORY "${CR_WRAPPERS_DIR}")
+
+set(CR_WRAPPERS_OBJ "${CR_WRAPPERS_DIR}/spl_cr_wrappers.obj")
+set(CR_WRAPPERS_LIB "${CR_WRAPPERS_DIR}/spl_cr_wrappers.lib")
+
+add_custom_command(
+    OUTPUT ${CR_WRAPPERS_LIB}
+    COMMAND ${MSVC_CL_EXECUTABLE} /nologo /c /Fo"${CR_WRAPPERS_OBJ}" ${CMAKE_SOURCE_DIR}/module/os/windows/spl/spl_cr_wrappers.c
+    COMMAND ${MSVC_LIB_EXECUTABLE} /nologo /OUT:${CR_WRAPPERS_LIB} /MACHINE:x64 ${CR_WRAPPERS_OBJ}
+    WORKING_DIRECTORY ${CR_WRAPPERS_DIR}
+    DEPENDS ${CMAKE_SOURCE_DIR}/module/os/windows/spl/spl_cr_wrappers.c
+    COMMENT "Building ${CR_WRAPPERS_LIB} in ${CR_WRAPPERS_DIR} using MSVC"
+)
+
+add_custom_target(cr_wrappers ALL DEPENDS ${CR_WRAPPERS_LIB})
+add_library(spl_cr_wrappers STATIC IMPORTED GLOBAL)
+set_target_properties(spl_cr_wrappers PROPERTIES
+    IMPORTED_LOCATION ${CR_WRAPPERS_LIB})
+

--- a/module/os/windows/spl/spl-windows.c
+++ b/module/os/windows/spl/spl-windows.c
@@ -73,7 +73,7 @@ uint32_t spl_hostid = 0;
 uint64_t
 __readcr8(void)
 {
-	return (0ULL);
+	return (read_cr8_msvc());
 }
 
 unsigned long

--- a/module/os/windows/spl/spl_cr_wrappers.c
+++ b/module/os/windows/spl/spl_cr_wrappers.c
@@ -1,0 +1,21 @@
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#include <stdint.h>
+
+// we can use the MSVC-specific intrinsic __readcr8() to read the value of the CR8
+// register directly. This intrinsic is part of MSVC's built-in functions,
+// which allows us to access hardware-level registers without writing assembly code.
+
+// Clang does not support the __readcr8 intrinsic, as it is specific to MSVC. 
+// Clang does not have a direct equivalent 
+// for accessing the CR8 register via a built-in function. Therefore, if we are using 
+// Clang, we must either use inline assembly or a different method to access the register.
+// https://learn.microsoft.com/en-us/cpp/intrinsics/readcr8?view=msvc-170
+
+__declspec(dllexport) uint64_t read_cr8_msvc(void) {
+    return __readcr8();
+}
+#else
+#error "_MSC_VER not defined"
+#endif

--- a/module/os/windows/zfs/CMakeLists.txt
+++ b/module/os/windows/zfs/CMakeLists.txt
@@ -47,4 +47,4 @@ zvol_os.c
 ${TMH_FILE_LIST}
 )
 
-target_link_libraries(zfskern_os PRIVATE splkern icpkern)
+target_link_libraries(zfskern_os PRIVATE splkern icpkern spl_cr_wrappers)


### PR DESCRIPTION
Create MSVC-specific wrapper library for reading CR8 register

Added a new C file that defines read_cr8_msvc(), which wraps the MSVC intrinsic __readcr8()
to read the CR8 register, since Clang and GCC do not provide __readcr8().

This function is now compiled into a separate library spl_cr_wrappers,
allowing Clang projects to call read_cr8_msvc() without directly depending
on MSVC-specific intrinsics in Clang code

See #101 to PSP20

Jira: SSV-24782
