### PR TITLE
SSV-24804 Import failure after reboot in windows 2025.

### DIFF
--- a/include/sys/efi_partition.h
+++ b/include/sys/efi_partition.h
@@ -73,6 +73,11 @@ typedef struct efi_gpe_Attrs {
 			RequiredPartition	:1;
 } efi_gpe_Attrs_t;
 
+/* MBR partition identification tags */
+#define	V_UNASSIGNED	0x00		/* unassigned partition */
+#define	V_USR		0x04		/* Usr filesystem */
+#define	V_RESERVED	0x0b		/* SMI reserved data */
+
 /*
  * 6a96237f-1dd2-11b2-99a6-080020736631	V_UNASSIGNED (not used as such)
  * 6a82cb45-1dd2-11b2-99a6-080020736631	V_BOOT
@@ -333,6 +338,21 @@ typedef struct dk_gpt {
 /* possible values for "efi_flags" */
 #define	EFI_GPT_PRIMARY_CORRUPT	0x1	/* primary label corrupt */
 
+#ifdef _WIN32
+/*
+ * Windows does not handle NumPartitions==9, and computes the CRC
+ * incorrectly, then wipes out (Primary) Partition Entry Array, and
+ * clears the GPT header. We define this flag to purposely skip
+ * the Primary label to read the backup. Windows does not clear the
+ * Backup Partition Entry Array. This will set EFI_GPT_PRIMARY_CORRUPT
+ * upon return, if they differ.
+ * The Windows port will (optionally) replace the
+ * blanked GPT header with the backup, but re-written with
+ * NumPartitions==128. (Which Windows does handle).
+ */
+#define	EFI_GPT_PRIMARY_SKIP	0x2 /* skip primary label, will set corrupt */
+#endif
+
 /* the private ioctl between libefi and the driver */
 typedef struct dk_efi {
 	diskaddr_t	 dki_lba;	/* starting block */
@@ -356,16 +376,25 @@ struct partition64 {
 /*
  * Number of EFI partitions
  */
-#if defined(__linux__)
+#if defined(__linux__) || defined(_WIN32)
 #define	EFI_NUMPAR	128 /* Expected by parted-1.8.1 */
 #else
 #define	EFI_NUMPAR	9
 #endif
 
 #ifndef _KERNEL
+#define	VT_ERROR	(-2)		/* errno supplies specific error */
+#define	VT_EIO		(-3)		/* I/O error accessing vtoc */
+#define	VT_EINVAL	(-4)		/* illegal value in vtoc or request */
+#define	VT_ENOSPC	(-6)		/* requested space not found */
+
 _SYS_EFI_PARTITION_H int efi_debug;
 _SYS_EFI_PARTITION_H int efi_alloc_and_init(int, uint32_t, struct dk_gpt **);
 _SYS_EFI_PARTITION_H int efi_alloc_and_read(int, struct dk_gpt **);
+#ifdef _WIN32
+_SYS_EFI_PARTITION_H int efi_alloc_and_read_flags(int, struct dk_gpt **,
+    uint_t);
+#endif
 _SYS_EFI_PARTITION_H int efi_write(int, struct dk_gpt *);
 _SYS_EFI_PARTITION_H int efi_rescan(int);
 _SYS_EFI_PARTITION_H void efi_free(struct dk_gpt *);

--- a/lib/libzfs/CMakeLists.txt
+++ b/lib/libzfs/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(libzfs
 	libzfs_sendrecv.c
 	libzfs_status.c
 	libzfs_util.c
+	os/windows/libzfs_disk_os.cpp
 	os/windows/libzfs_mount_os.c
 	os/windows/libzfs_pool_os.c
 	os/windows/libzfs_util_os.c

--- a/lib/libzfs/os/windows/libzfs_disk_os.cpp
+++ b/lib/libzfs/os/windows/libzfs_disk_os.cpp
@@ -1,0 +1,164 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+  * Copyright 2025 Jorgen Lundman <lundman@lundman.net>.
+  */
+
+
+
+//
+// This code is rediculous.
+//
+
+#include <windows.h>
+#include <wbemidl.h>
+#include <comdef.h>
+#pragma comment(lib, "wbemuuid.lib")
+
+extern "C" HRESULT OfflineDisk(const char *devicePath);
+extern "C" HRESULT OnlineDisk(const char *devicePath);
+
+// Call with diskPath = "\\\\.\\PhysicalDrive2"
+// offline == TRUE >> Offline(), FALSE >> Online()
+HRESULT
+process_disk(const char *diskPath, BOOL offline)
+{
+	HRESULT hr;
+	IWbemLocator *pLoc = NULL;
+	IWbemServices *pSvc = NULL;
+	IEnumWbemClassObject *pEnum = NULL;
+	IWbemClassObject *pObj = NULL;
+
+	// 1) Initialize COM
+	hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	if (FAILED(hr)) return hr;
+
+	// 2) Set general COM security levels
+	hr = CoInitializeSecurity(
+		NULL,                       // security descriptor
+		-1,                         // COM negotiates 
+		NULL,                       // auth services
+		NULL,                       // reserved
+		RPC_C_AUTHN_LEVEL_DEFAULT,  // default authentication 
+		RPC_C_IMP_LEVEL_IMPERSONATE,// default Impersonation  
+		NULL,                       // authentication list
+		EOAC_NONE,                  // capabilities 
+		NULL                        // reserved
+	);
+	if (FAILED(hr)) goto cleanup;
+
+	// 3) Obtain the initial locator to WMI
+	hr = CoCreateInstance(
+		CLSID_WbemLocator,
+		NULL,
+		CLSCTX_INPROC_SERVER,
+		IID_IWbemLocator, (LPVOID *)&pLoc);
+	if (FAILED(hr))
+		goto cleanup;
+
+	// 4) Connect to the ROOT\CIMV2 namespace
+	hr = pLoc->ConnectServer(
+		_bstr_t(L"ROOT\\CIMV2"), // WMI namespace
+		NULL,                    // user 
+		NULL,                    // password 
+		0,                       // locale 
+		NULL,                    // security flags
+		0,                       // authority 
+		0,                       // context 
+		&pSvc                    // IWbemServices pointer
+	);
+	if (FAILED(hr)) goto cleanup;
+
+	// 5) Set security levels on the proxy
+	hr = CoSetProxyBlanket(
+		pSvc,                        // proxy
+		RPC_C_AUTHN_WINNT,           // auth service
+		RPC_C_AUTHZ_NONE,            // authorization service
+		NULL,                        // principal
+		RPC_C_AUTHN_LEVEL_CALL,      // auth level
+		RPC_C_IMP_LEVEL_IMPERSONATE, // impersonation
+		NULL,                        // identity
+		EOAC_NONE                    // capabilities
+	);
+	if (FAILED(hr))
+		goto cleanup;
+
+	// 6) Query for the specific disk by DeviceID
+	{
+		wchar_t query[256];
+		swprintf(query, sizeof(query) / sizeof(wchar_t),
+			L"SELECT * FROM Win32_DiskDrive WHERE DeviceID = '%s'", diskPath);
+
+		hr = pSvc->ExecQuery(
+			bstr_t("WQL"),
+			bstr_t(query),
+			WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+			NULL,
+			&pEnum);
+		if (FAILED(hr)) goto cleanup;
+	}
+
+	// 7) Get the first result (there should only be one)
+	ULONG returned = 0;
+	hr = pEnum->Next(WBEM_INFINITE, 1, &pObj, &returned);
+	if (FAILED(hr) || returned == 0) {
+		hr = WBEM_E_NOT_FOUND;
+		goto cleanup;
+	}
+
+	// 8) Invoke Offline() or Online()
+	{
+		BSTR method = offline ? SysAllocString(L"Offline") : SysAllocString(L"Online");
+		hr = pSvc->ExecMethod(
+			NULL,           // object path; if NULL, must set __PATH in pInParams
+			method,
+			0,
+			NULL,
+			NULL,
+			NULL,
+			NULL);
+		SysFreeString(method);
+	}
+
+cleanup:
+	if (pObj)    pObj->Release();
+	if (pEnum)   pEnum->Release();
+	if (pSvc)    pSvc->Release();
+	if (pLoc)    pLoc->Release();
+	CoUninitialize();
+	return hr;
+}
+
+
+
+HRESULT
+OfflineDisk(const char *devicePath)
+{
+	return (process_disk(devicePath, TRUE));
+}
+
+HRESULT
+OnlineDisk(const char *devicePath)
+{
+	return (process_disk(devicePath, FALSE));
+}
+

--- a/lib/libzfs/os/windows/libzfs_pool_os.c
+++ b/lib/libzfs/os/windows/libzfs_pool_os.c
@@ -35,14 +35,12 @@
 #include <libintl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
 #include <unistd.h>
 #include <libgen.h>
 #include <zone.h>
 #include <sys/stat.h>
 #include <sys/efi_partition.h>
 #include <sys/systeminfo.h>
-#include <sys/vtoc.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/vdev_disk.h>
 #include <dlfcn.h>
@@ -53,6 +51,9 @@
 #include "libzfs_impl.h"
 #include "zfs_comutil.h"
 #include "zfeature_common.h"
+
+HRESULT OfflineDisk(const char *devicePath);
+HRESULT OnlineDisk(const char *devicePath);
 
 /*
  * If the device has being dynamically expanded then we need to relabel
@@ -208,6 +209,164 @@ zpool_label_name(char *label_name, int label_size)
 	snprintf(label_name, label_size, "zfs-%016llx", (u_longlong_t)id);
 }
 
+void
+dump_label(int fd)
+{
+	struct dk_gpt *vtoc;
+	int err;
+	if (efi_alloc_and_read(fd, &vtoc) != 0) {
+		fprintf(stderr, "Failed to read label\n");
+		return;
+	}
+	fprintf(stderr,
+	    "EFI read OK, max partitions %d\n",
+	    vtoc->efi_nparts);
+	fflush(stderr);
+	for (int i = 0; i < vtoc->efi_nparts; i++) {
+		fprintf(stderr,
+		    "    part %d:  offset %llx:    len %llx:    "
+		    "tag: %x    name: '%s'\n",
+		    i, vtoc->efi_parts[i].p_start,
+		    vtoc->efi_parts[i].p_size,
+		    vtoc->efi_parts[i].p_tag,
+		    vtoc->efi_parts[i].p_name);
+		fflush(stderr);
+		if (i > 11) break;
+	}
+	efi_free(vtoc);
+}
+
+void
+process_volumes(HANDLE hDisk)
+{
+	// Step 1: Get physical disk number
+	STORAGE_DEVICE_NUMBER devNum;
+	DWORD bytesReturned;
+	if (!DeviceIoControl(hDisk,
+	    IOCTL_STORAGE_GET_DEVICE_NUMBER,
+	    NULL, 0,
+	    &devNum, sizeof (devNum),
+	    &bytesReturned, NULL)) {
+		fprintf(stderr, "Failed to get device number: %lu\n",
+		    GetLastError());
+		return;
+	}
+
+	DWORD targetDiskNumber = devNum.DeviceNumber;
+
+	// Step 2: Enumerate all volumes
+	WCHAR volumeName[MAX_PATH];
+	HANDLE hFind = FindFirstVolumeW(volumeName,
+	    ARRAYSIZE(volumeName));
+	if (hFind == INVALID_HANDLE_VALUE) {
+		fprintf(stderr, "FindFirstVolumeW failed: %lu\n",
+		    GetLastError());
+		return;
+	}
+
+	do {
+		// Remove trailing backslash for CreateFileW
+		size_t len = wcslen(volumeName);
+		if (volumeName[len - 1] == L'\\') {
+			volumeName[len - 1] = L'\0';
+		}
+
+		HANDLE hVol = CreateFileW(volumeName,
+		    GENERIC_READ | GENERIC_WRITE,
+		    FILE_SHARE_READ | FILE_SHARE_WRITE,
+		    NULL, OPEN_EXISTING, 0, NULL);
+
+		if (hVol == INVALID_HANDLE_VALUE)
+			continue;
+
+		// Step 3: Check disk extents
+		VOLUME_DISK_EXTENTS extents;
+		if (!DeviceIoControl(hVol,
+		    IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
+		    NULL, 0,
+		    &extents, sizeof (extents),
+		    &bytesReturned, NULL)) {
+			CloseHandle(hVol);
+			continue;
+		}
+
+		for (DWORD i = 0;
+		    i < extents.NumberOfDiskExtents;
+		    ++i) {
+			if (extents.Extents[i].DiskNumber ==
+			    targetDiskNumber) {
+				fwprintf(stderr,
+				    L"Volume %s is on PHYSICALDRIVE%lu\n",
+				    volumeName, targetDiskNumber);
+
+				// Try to lock and dismount
+				if (DeviceIoControl(hVol, FSCTL_LOCK_VOLUME,
+				    NULL, 0, NULL, 0, &bytesReturned, NULL)) {
+					fprintf(stderr, "  Locked.\n");
+					if (DeviceIoControl(hVol,
+					    FSCTL_DISMOUNT_VOLUME, NULL, 0,
+					    NULL, 0, &bytesReturned, NULL)) {
+						fprintf(stderr,
+						    "  Dismounted.\n");
+					} else {
+						fprintf(stderr,
+						    "  Dismount: %lu\n",
+						    GetLastError());
+					}
+				} else {
+					fprintf(stderr,
+					    "  Failed to lock: %lu\n",
+					    GetLastError());
+				}
+			}
+		}
+
+		CloseHandle(hVol);
+
+		// Restore trailing slash
+		volumeName[len - 1] = L'\\';
+	} while (FindNextVolumeW(hFind, volumeName, ARRAYSIZE(volumeName)));
+
+	FindVolumeClose(hFind);
+	fflush(stderr);
+}
+
+int
+efi_tryexclusive(int fd, const char *path)
+{
+	int retry = 0;
+
+	fprintf(stderr, "%s: fd %d\r\n", __func__, fd);
+
+	// Tell Windows to bugger off, we are about to wipe this
+	process_volumes(fd);
+
+	// Lets try to reopen exclusive
+	close(fd);
+	fd = -1;
+
+	fprintf(stderr, "%s: trying to offline disk\r\n", __func__);
+	OfflineDisk(path);
+
+	fprintf(stderr, "%s: trying for exclusive access\r\n", __func__);
+
+	do {
+		if ((fd = open(path, O_RDWR|O_DIRECT|O_EXCL|O_EXLOCK)) >= 0)
+			break;
+		usleep(500);
+	} while (retry++ < 3);
+
+	if (fd >= 0) {
+		fprintf(stderr, "%s: success. fd is %d\r\n", __func__, fd);
+	} else {
+		fprintf(stderr, "%s: failed, continuing with shared access\r\n",
+		    __func__);
+		fd = open(path, O_RDWR | O_DIRECT | O_EXCL);
+	}
+
+	return (fd);
+}
+
 /*
  * Label an individual disk.  The name provided is the short name,
  * stripped of any leading /dev path.
@@ -228,10 +387,8 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 	    dgettext(TEXT_DOMAIN, "cannot label '%s'"), name);
 
 	if (zhp) {
-		nvlist_t *nvroot;
-
-		verify(nvlist_lookup_nvlist(zhp->zpool_config,
-		    ZPOOL_CONFIG_VDEV_TREE, &nvroot) == 0);
+		nvlist_t *nvroot = fnvlist_lookup_nvlist(zhp->zpool_config,
+		    ZPOOL_CONFIG_VDEV_TREE);
 
 		if (zhp->zpool_start_block == 0)
 			start_block = find_start_block(nvroot);
@@ -255,6 +412,9 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 		return (zfs_error(hdl, EZFS_OPENFAILED, errbuf));
 	}
 
+	// This might re-open fd exclusively if it can
+	fd = efi_tryexclusive(fd, path);
+
 	if (efi_alloc_and_init(fd, EFI_NUMPAR, &vtoc) != 0) {
 		/*
 		 * The only way this can fail is if we run out of memory, or we
@@ -266,6 +426,9 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 		(void) close(fd);
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN, "cannot "
 		    "label '%s': unable to read disk capacity"), path);
+
+		fprintf(stderr, "%s: trying to online disk\r\n", __func__);
+		OnlineDisk(path);
 
 		return (zfs_error(hdl, EZFS_NOCAP, errbuf));
 	}
@@ -290,7 +453,16 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 	 */
 	vtoc->efi_parts[0].p_tag = V_USR;
 	zpool_label_name(vtoc->efi_parts[0].p_name, EFI_PART_NAME_LEN);
+#if 0
+	for (int i = 1; i < 8; i++) {
+		vtoc->efi_parts[i].p_tag = V_RESERVED;
+		vtoc->efi_parts[i].p_start = slice_size + start_block;
 
+//		vtoc->efi_parts[i].p_size = 1;
+//		resv -= 1;
+//		start_block += 1;
+	}
+#endif
 	vtoc->efi_parts[8].p_start = slice_size + start_block;
 	vtoc->efi_parts[8].p_size = resv;
 	vtoc->efi_parts[8].p_tag = V_RESERVED;
@@ -303,6 +475,15 @@ zpool_label_disk(libzfs_handle_t *hdl, zpool_handle_t *zhp, const char *name)
 
 	if (rval == 0)
 		rval = efi_rescan(fd);
+
+	dump_label(fd);
+
+	fprintf(stderr, "%s: trying to online disk\r\n", __func__);
+	rval = OnlineDisk(path);
+	if (SUCCEEDED(rval))
+		fprintf(stderr, "%s: failed %d (0x%x)\r\n", __func__,
+		    rval, rval);
+	rval = 0;
 
 	/*
 	 * Some block drivers (like pcata) may not support EFI GPT labels.


### PR DESCRIPTION
- Manually integrated minimal upstream changes to address Windows 2025 compatibility. (Creating 128 partitions instead of 9 while creating ZPool)
- Adapted key updates from libzfs_pool_os.c and selectively applied related changes for a minimal integration.


Upstream commit references:
1. 8cdc742b569a4ae28345300f046040983a865604
2. dfbf6c5e64f2fab6d8a83753a5ba4f3b394c0291
3. 8deac95c7a28350083682d12fde306103e14a652
4. 991d1a38f9bba1d9043879a0c4fcac1c80cb546d
5. 63fcad5882e212a4895f3f831e761cec582ad0b4

Ran CI runs with the fix in Windows2025- 
1. https://ci.datacoresoftware.com/buildConfiguration/InfrastructureDeployment_TestAutomationDevAsh2025/427108?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildDeploymentsSection=false
2. https://ci.datacoresoftware.com/buildConfiguration/InfrastructureDeployment_TestAutomationDevAsh2025/427131?hideTestsFromDependencies=false&hideProblemsFromDependencies=false

Upgrade case tested in https://dcsw.atlassian.net/browse/TA-7063
Jira : SSV-24804, SSV-24793