### PR TITLE
SSV-24778 "DF - InfVerif Inf Verification" HLK test is failing for 2025 OS

### DIFF
--- a/module/os/windows/ZFSin.inf
+++ b/module/os/windows/ZFSin.inf
@@ -12,6 +12,7 @@ ClassGuid   = {71a27cdd-812a-11d0-bec7-08002be2092f}
 Provider    = %Me%
 DriverVer   = 05/19/2018,1.0.2.0
 CatalogFile = ZFSin.cat
+PnpLockDown=0
 
 [DestinationDirs]
 DefaultDestDir          = 12


### PR DESCRIPTION
ISSUE: "DF - InfVerif Inf Verification" HLK test is failing in many drivers for 2025 OS

CAUSE: HLK test requires the PnpLockdown to be set in Win2025 to get passed

FIX: Added the PnpLockdown attribute to all the drivers

TEST by Dev: created a private branch and able to pass the test in Win2025

TEST for QA: Run all the HLK test in all the supported OSes

DRIVERS AFFECTED: ZFSin.sys
JIRAs done: [SSV-24778](https://dcsw.atlassian.net/browse/SSV-24778)

[SSV-24778]: https://dcsw.atlassian.net/browse/SSV-24778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ