### PR TITLE
SSV-25461 High latency due to ZFSin driver

### DIFF
--- a/include/os/windows/spl/sys/sysmacros.h
+++ b/include/os/windows/spl/sys/sysmacros.h
@@ -81,9 +81,9 @@ extern unsigned int num_ecores;
  * swap priority is at 92. Most ZFS priorities should probably
  * stay below this, but kmem_reap needs to be higher.
  */
-#define	minclsyspri  81 /* BASEPRI_KERNEL */
-#define	defclsyspri  81 /* BASEPRI_KERNEL */
-#define	maxclsyspri  89
+#define	minclsyspri  8 /* BASEPRI_KERNEL */
+#define	defclsyspri  8 /* BASEPRI_KERNEL */
+#define	maxclsyspri  12
 
 #define	NICE_TO_PRIO(nice)		(MAX_RT_PRIO + (nice) + 20)
 #define	PRIO_TO_NICE(prio)		((prio) - MAX_RT_PRIO - 20)

--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -150,7 +150,7 @@ typedef struct windows_kstat {
 	kstat_named_t zfs_removal_suspend_progress;
 	kstat_named_t cpu_avx_supported;
 	kstat_named_t zvol_io_threads;
-	kstat_named_t zfs_abd_prealloc_percent;
+	kstat_named_t zfs_prealloc_percent;
 } windows_kstat_t;
 
 
@@ -262,7 +262,7 @@ extern int zfs_autoimport_disable;
 extern int zfs_removal_suspend_progress;
 extern int cpu_avx_supported;
 extern int zvol_threads;
-extern int zfs_abd_prealloc_percent;
+extern int zfs_prealloc_percent;
 
 int  kstat_windows_init(void *);
 void kstat_windows_fini(void);

--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -150,6 +150,7 @@ typedef struct windows_kstat {
 	kstat_named_t zfs_removal_suspend_progress;
 	kstat_named_t cpu_avx_supported;
 	kstat_named_t zvol_io_threads;
+	kstat_named_t zfs_abd_prealloc_percent;
 } windows_kstat_t;
 
 
@@ -261,6 +262,7 @@ extern int zfs_autoimport_disable;
 extern int zfs_removal_suspend_progress;
 extern int cpu_avx_supported;
 extern int zvol_threads;
+extern int zfs_abd_prealloc_percent;
 
 int  kstat_windows_init(void *);
 void kstat_windows_fini(void);

--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -88,6 +88,7 @@ typedef struct windows_kstat {
 	kstat_named_t spa_mode_global;
 	kstat_named_t zfs_flags;
 	kstat_named_t zfs_txg_timeout;
+	kstat_named_t zfs_adc_enable;
 	kstat_named_t zfs_vdev_cache_max;
 	kstat_named_t zfs_vdev_cache_size;
 	kstat_named_t zfs_vdev_cache_bshift;
@@ -151,6 +152,7 @@ typedef struct windows_kstat {
 	kstat_named_t cpu_avx_supported;
 	kstat_named_t zvol_io_threads;
 	kstat_named_t zfs_prealloc_percent;
+	kstat_named_t zfs_adc_target_sync_pct;
 } windows_kstat_t;
 
 
@@ -263,6 +265,7 @@ extern int zfs_removal_suspend_progress;
 extern int cpu_avx_supported;
 extern int zvol_threads;
 extern int zfs_prealloc_percent;
+extern uint_t zfs_adc_target_sync_pct;
 
 int  kstat_windows_init(void *);
 void kstat_windows_fini(void);

--- a/include/os/windows/zfs/sys/kstat_windows.h
+++ b/include/os/windows/zfs/sys/kstat_windows.h
@@ -273,5 +273,6 @@ void kstat_windows_fini(void);
 int arc_kstat_update(kstat_t *ksp, int rw);
 int arc_kstat_update_windows(kstat_t *ksp, int rw);
 int spl_kstat_registry(void *pRegistryPath, kstat_t *ksp);
+int dynamic_dirty_data_kstat_update(kstat_t* ksp, int rw);
 
 #endif

--- a/include/sys/arc.h
+++ b/include/sys/arc.h
@@ -78,6 +78,7 @@ typedef void arc_prune_func_t(int64_t bytes, void *priv);
 
 /* Shared module parameters */
 extern int zfs_arc_average_blocksize;
+extern uint64_t dirty_ceil_bytes;
 
 /* generic arc_done_func_t's which you can use */
 arc_read_done_func_t arc_bcopy_func;

--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -139,6 +139,8 @@ extern void *txg_list_next(txg_list_t *tl, void *p, uint64_t txg);
 
 /* Global tuning */
 extern int zfs_txg_timeout;
+extern int zfs_adc_enable;
+extern uint_t zfs_adc_target_sync_pct;
 
 
 #ifdef ZFS_DEBUG

--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -142,6 +142,11 @@ extern int zfs_txg_timeout;
 extern int zfs_adc_enable;
 extern uint_t zfs_adc_target_sync_pct;
 
+typedef struct dynamic_dirty_data_stats {
+    kstat_named_t adc_target;
+    kstat_named_t spa_sync_time;
+    kstat_named_t data_flushed_per_sync;
+} dynamic_dirty_data_stats_t;
 
 #ifdef ZFS_DEBUG
 #define	TXG_VERIFY(spa, txg)		txg_verify(spa, txg)

--- a/include/sys/txg.h
+++ b/include/sys/txg.h
@@ -146,6 +146,7 @@ typedef struct dynamic_dirty_data_stats {
     kstat_named_t adc_target;
     kstat_named_t spa_sync_time;
     kstat_named_t data_flushed_per_sync;
+    kstat_named_t total_dirty_data;
 } dynamic_dirty_data_stats_t;
 
 #ifdef ZFS_DEBUG

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -132,6 +132,10 @@ extern uint64_t		zfs_active_rwlock;
 extern uint64_t		total_memory;
 extern uint64_t		real_total_memory;
 
+extern kmem_cache_t *abd_chunk_cache;
+extern uint64_t zfs_arc_max;
+extern int zfs_prealloc_percent;
+
 #define	MULT 1
 
 static const char *KMEM_VA_PREFIX = "kmem_va";
@@ -4304,10 +4308,7 @@ spl_free_set_pressure(int64_t new_p)
 		// and any spl_free_set_and_wait_pressure() threads
 		cv_broadcast(&spl_free_thread_cv);
 	}
-	if (new_p > 0)
-		spl_free_last_pressure = zfs_lbolt();
-	else
-		spl_free_last_pressure = zfs_lbolt();
+	spl_free_last_pressure = zfs_lbolt();
 }
 
 void
@@ -4923,10 +4924,6 @@ spl_event_thread(void *notused)
 	thread_exit();
 }
 
-extern kmem_cache_t *abd_chunk_cache;
-extern uint64_t zfs_arc_max;
-extern int zfs_abd_prealloc_percent;
-
 static void
 spl_abd_prealloc_thread(void *notused)
 {
@@ -4952,13 +4949,14 @@ spl_abd_prealloc_thread(void *notused)
 			delay(hz);
 			continue;
 		}
-		node = (abd_prealloc_node_t *)kmem_cache_alloc(abd_chunk_cache, KM_SLEEP);
-		list_insert_tail(&abd_prealloc_list, node);
 
 		if (segkmem_total_mem_allocated >=
-                    (zfs_arc_max * zfs_abd_prealloc_percent) / 100) {
+                    (zfs_arc_max * zfs_prealloc_percent) / 100) {
                         break;
                 }
+
+		node = (abd_prealloc_node_t *)kmem_cache_alloc(abd_chunk_cache, KM_SLEEP);
+		list_insert_tail(&abd_prealloc_list, node);
 	}
 
 	while ((node = list_remove_head(&abd_prealloc_list)) != NULL) {
@@ -4969,7 +4967,7 @@ spl_abd_prealloc_thread(void *notused)
 	dprintf("SPL: %s thread_exit\n", __func__);
 
 	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "SPL: abd prealloc done segkmem_total_mem_allocated: %lld total_memory: %lld zfs_arc_max: %llu zfs_prealloc_percent: %d%\n",
-	    segkmem_total_mem_allocated, total_memory, zfs_arc_max, zfs_abd_prealloc_percent));
+	    segkmem_total_mem_allocated, total_memory, zfs_arc_max, zfs_prealloc_percent));
 	thread_exit();
 }
 
@@ -5401,11 +5399,13 @@ spl_kmem_thread_init(void)
 	(void) thread_create(NULL, 0, spl_free_thread, 0, 0, 0, 0, 92);
 	spl_free_thread_running = TRUE;
 
-	//spl_event_thread_exit = FALSE;
-	//(void) thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);
-
-	spl_abd_prealloc_thread_exit = FALSE;
-	(void) thread_create(NULL, 0, spl_abd_prealloc_thread, 0, 0, 0, 0, 92);
+	if (zfs_prealloc_percent) {
+		spl_abd_prealloc_thread_exit = FALSE;
+		(void) thread_create(NULL, 0, spl_abd_prealloc_thread, 0, 0, 0, 0, 92);
+	} else {
+		spl_event_thread_exit = FALSE;
+		(void) thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);
+	}
 }
 
 void

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -4234,8 +4234,15 @@ spl_free_wrapper(void)
 // when arc_reclaim_thread() calls spl_free_set_pressure(0);
 int64_t
 spl_free_manual_pressure_wrapper(void)
-{
-	return (0);
+{      	
+    if (arc_target_size() >= ((zfs_arc_max * 95ULL) / 100ULL)) {
+	return (spl_free_manual_pressure); 
+    }
+    else if ((segkmem_total_mem_allocated * 100ULL) / total_memory > 95) {
+	return (spl_free_manual_pressure);
+    }
+        
+    return (0);
 }
 
 uint64_t

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -4235,7 +4235,7 @@ spl_free_wrapper(void)
 int64_t
 spl_free_manual_pressure_wrapper(void)
 {
-	return (spl_free_manual_pressure);
+	return (0);
 }
 
 uint64_t

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -76,6 +76,7 @@ static volatile _Atomic int64_t spl_free = 0;
 int64_t spl_free_delta_ema;
 
 static boolean_t spl_event_thread_exit = FALSE;
+static boolean_t spl_abd_prealloc_thread_exit = FALSE;
 PKEVENT low_mem_event = NULL;
 
 static volatile _Atomic int64_t spl_free_manual_pressure = 0;
@@ -4914,6 +4915,56 @@ spl_event_thread(void *notused)
 	thread_exit();
 }
 
+extern kmem_cache_t *abd_chunk_cache;
+extern uint64_t zfs_arc_max;
+extern int zfs_abd_prealloc_percent;
+
+static void
+spl_abd_prealloc_thread(void *notused)
+{
+	NTSTATUS Status;
+
+	typedef struct abd_prealloc_node {
+		list_node_t node;
+	} abd_prealloc_node_t;
+
+	abd_prealloc_node_t *node;
+	list_t abd_prealloc_list;
+
+	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "SPL: abd prealloc start segkmem_total_mem_allocated: %lld total_memory: %lld\n",
+	    segkmem_total_mem_allocated, total_memory));
+
+	dprintf("SPL: beginning spl_abd_prealloc_thread() loop\n");
+
+	list_create(&abd_prealloc_list, sizeof (abd_prealloc_node_t), offsetof(abd_prealloc_node_t, node));
+
+	while (!spl_abd_prealloc_thread_exit) {
+
+		if (!abd_chunk_cache || !zfs_arc_max) {
+			delay(hz);
+			continue;
+		}
+		node = (abd_prealloc_node_t *)kmem_cache_alloc(abd_chunk_cache, KM_SLEEP);
+		list_insert_tail(&abd_prealloc_list, node);
+
+		if (segkmem_total_mem_allocated >=
+                    (zfs_arc_max * zfs_abd_prealloc_percent) / 100) {
+                        break;
+                }
+	}
+
+	while ((node = list_remove_head(&abd_prealloc_list)) != NULL) {
+		kmem_cache_free(abd_chunk_cache, node);
+	}
+
+	spl_abd_prealloc_thread_exit = FALSE;
+	dprintf("SPL: %s thread_exit\n", __func__);
+
+	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "SPL: abd prealloc done segkmem_total_mem_allocated: %lld total_memory: %lld zfs_prealloc_percent: %d%\n",
+	    segkmem_total_mem_allocated, total_memory, zfs_abd_prealloc_percent));
+	thread_exit();
+}
+
 
 static int
 spl_kstat_update(kstat_t *ksp, int rw)
@@ -5344,6 +5395,9 @@ spl_kmem_thread_init(void)
 
 	spl_event_thread_exit = FALSE;
 	(void) thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);
+
+	spl_abd_prealloc_thread_exit = FALSE;
+	(void) thread_create(NULL, 0, spl_abd_prealloc_thread, 0, 0, 0, 0, 92);
 }
 
 void
@@ -5351,6 +5405,7 @@ spl_kmem_thread_fini(void)
 {
 	shutting_down = 1;
 
+	spl_abd_prealloc_thread_exit = TRUE;
 	if (low_mem_event != NULL) {
 		dprintf("SPL: stopping spl_event_thread\n");
 		spl_event_thread_exit = TRUE;

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * CDDL HEADER START
  *
  * The contents of this file are subject to the terms of the
@@ -88,6 +88,24 @@ _Atomic uint32_t spl_vm_pages_reclaimed = 0;
 _Atomic uint32_t spl_vm_pages_wanted = 0;
 _Atomic uint32_t spl_vm_pressure_level = 0;
 
+/*
+ * Global flag set by prealloc thread.
+ *
+ * PREALLOC_PHASE_IDLE     : prealloc not running
+ * PREALLOC_PHASE_ALLOC    : thread is allocating (Phase 1)
+ *                           free_warm ≈ 0, pressure is FAKE → suppress
+ * PREALLOC_PHASE_FREE     : thread is freeing back to slab (Phase 2)
+ *                           free_warm growing, discount valid
+ * PREALLOC_PHASE_DONE     : prealloc complete, normal operation
+ */
+typedef enum {
+    PREALLOC_PHASE_IDLE = 0,
+    PREALLOC_PHASE_ALLOC = 1,
+    PREALLOC_PHASE_FREE = 2,
+    PREALLOC_PHASE_DONE = 3,
+} prealloc_phase_t;
+
+volatile prealloc_phase_t prealloc_phase = PREALLOC_PHASE_IDLE;
 
 /*
  * the spl_pressure_level enum only goes to four,
@@ -4223,6 +4241,39 @@ kmem_cache_fini()
 	list_destroy(&freelist);
 }
 
+static int64_t
+abd_free_warm_bytes(void)
+{
+    extern vmem_t* abd_arena;
+
+    /*
+     * During Phase 1 (prealloc allocating), mem_inuse ≈ mem_import
+     * so free_warm ≈ 0 anyway, but guard explicitly to be clear.
+     */
+    if (abd_arena == NULL ||
+	prealloc_phase == PREALLOC_PHASE_ALLOC ||
+	prealloc_phase == PREALLOC_PHASE_IDLE)
+	return (0);
+
+    const int64_t mem_import =
+	(int64_t)abd_arena->vm_kstat.vk_mem_import.value.ui64;
+    const int64_t mem_inuse =
+	(int64_t)abd_arena->vm_kstat.vk_mem_inuse.value.ui64;
+
+    return ((mem_import > mem_inuse) ? (mem_import - mem_inuse) : 0);
+}
+
+static bool
+critical_memory_state(int64_t bufferzone, int64_t *rem)
+{   
+    const int64_t remainder = (int64_t)total_memory - (int64_t)segkmem_total_mem_allocated;
+    if (rem != NULL) {
+	*rem = remainder;
+    }
+
+    return (remainder < bufferzone);
+}
+
 // this is intended to substitute for kmem_avail() in arc.c
 int64_t
 spl_free_wrapper(void)
@@ -4232,127 +4283,139 @@ spl_free_wrapper(void)
 
     extern vmem_t* abd_arena;
 
-    /*
-     * If abd_arena is not yet initialized, fall back to the standard
-     * spl_free path rather than returning 0 (which would block ARC growth).
-     */
     if (abd_arena == NULL)
 	return (spl_free);
 
     /*
-     * Read abd_cache vmem kstat counters.
-     *
-     * mem_import: total bytes committed from OS to abd_cache slabs.
-     *             This is fully counted in os_mem_alloc.
-     * mem_inuse:  bytes actively held by live ABD objects (ARC data).
-     * free_warm:  mem_import - mem_inuse
-     *             Memory OS has committed, sitting free in the slab.
-     *             ARC can consume this at zero additional OS cost.
-     *             os_mem_alloc counts this as "used" � that is wrong
-     *             from ARC's perspective, so we discount it.
+     * During prealloc Phase 1 (allocating), free_warm = 0 and
+     * segkmem_total_mem_allocated is artificially high.
+     * Fall back to spl_free to avoid negative available values
+     * that would trigger an immediate arc_evict storm.
      */
-    const int64_t mem_import =
-	(int64_t)abd_arena->vm_kstat.vk_mem_import.value.ui64;
-    const int64_t mem_inuse =
-	(int64_t)abd_arena->vm_kstat.vk_mem_inuse.value.ui64;
+    if (prealloc_phase == PREALLOC_PHASE_ALLOC ||
+	prealloc_phase == PREALLOC_PHASE_IDLE)
+	return (spl_free);
+
+    const int64_t free_warm = abd_free_warm_bytes();
 
     /*
-     * Sanity: mem_import should always be >= mem_inuse.
-     * Guard against transient races where counters are momentarily
-     * inconsistent (both updated non-atomically by vmem internals).
-     */
-    const int64_t free_warm =
-	(mem_import > mem_inuse) ? (mem_import - mem_inuse) : 0;
-
-    /*
-     * Effective OS pressure = what os_mem_alloc reports, minus the
-     * portion that is free in the slab (pre-paid by prealloc, costs
-     * nothing for ARC to consume).
-     *
-     * os_mem_alloc is extern'd from spl-vmem.c � same source spl_free uses.
+     * Effective OS pressure: discount free-warm slab memory.
+     * These bytes are already counted in segkmem_total_mem_allocated
+     * but cost ARC nothing to consume.
      */
     const int64_t effective_os_alloc =
-	segkmem_total_mem_allocated - free_warm;
+	MAX((int64_t)segkmem_total_mem_allocated - free_warm, 0);
 
-    /*
-     * OS headroom: how much more can we allocate before hitting the
-     * system memory ceiling. Cast total_memory to int64_t BEFORE
-     * multiplying to avoid uint64_t overflow.
-     */
+    /* 95% of physical RAM — ceiling before we start hurting the OS */
     const int64_t memory_limit =
-	((int64_t)total_memory * 95) / 100;   /* 95% of physical RAM */
+	((int64_t)total_memory * 95) / 100;
 
     const int64_t os_headroom = memory_limit - effective_os_alloc;
-
-    /*
-     * ARC headroom: how far below arc_max is arc_c right now.
-     * ARC must never grow past arc_max regardless of OS headroom.
-     */
     const int64_t arc_headroom =
-	zfs_arc_max - arc_target_size();
+	(int64_t)zfs_arc_max - arc_target_size();
+
+    const int64_t available = MIN(os_headroom, arc_headroom);
 
     /*
-     * Available = minimum of both constraints.
-     * Clamp to spl_free as a lower bound so we never report
-     * more freedom than the base (non-prealloc) path would.
+     * Floor at spl_free: never return a value more pessimistic
+     * than what the base pressure path reports. This ensures
+     * the prealloc path is strictly an optimistic correction.
      */
-    const int64_t available = MIN(os_headroom, arc_headroom);
-    
-    return available;
-}
-
-bool critical_memory_state(int64_t bufferzone)
-{
-    int64_t remainder = (total_memory - segkmem_total_mem_allocated);
-    if (remainder < bufferzone) return 1;
-    return 0;
+    return (MAX(available, spl_free));
 }
 
 // this is intended to substitute for kmem_avail() in arc.c
 // when arc_reclaim_thread() calls spl_free_set_pressure(0);
 int64_t
 spl_free_manual_pressure_wrapper(void)
-{   
-    int64_t five_percent = (total_memory * 5) / 100;
-    int64_t five_hundred_mb = 500LL * 1024 * 1024; // 500 MB in bytes
+{
+    /*
+     * Persisted across calls.
+     *   last_shrink_time - when we last issued a non-zero reduction.
+     *   inflight_reduce  - bytes already requested but not yet seen reclaimed
+     *                      in the OS counters. This is what stops rapid repeat
+     *                      calls from stacking reductions on top of each other.
+     */
+    static hrtime_t last_shrink_time = 0;
+    static int64_t  inflight_reduce = 0;
 
-    int64_t buffer_zone = MIN(five_hundred_mb, five_percent);
-    int64_t safe_threshold = total_memory - buffer_zone;
+    const hrtime_t now = gethrtime();
+    const hrtime_t settle_ns = SEC2NSEC(1);   /* assumed reclaim latency */
 
-    if (critical_memory_state(buffer_zone)) return 500LL * 1024 * 1024;
+    const int64_t five_percent = ((int64_t)total_memory * 5) / 100;
+    const int64_t five_hundred_mb = 500LL * 1024 * 1024;
+    const int64_t buffer_zone = MIN(five_hundred_mb, five_percent);
 
-    extern vmem_t* abd_arena;
+    /*
+     * Bleed off the in-flight estimate, modeled as draining linearly over
+     * settle_ns; anything older is treated as fully reclaimed. This single
+     * change is what makes the function safe to call at any frequency.
+     */
+    if (inflight_reduce > 0) {
+	const hrtime_t age = now - last_shrink_time;
+	if (age >= settle_ns)
+	    inflight_reduce = 0;
+	else
+	    inflight_reduce -= (inflight_reduce * age) / settle_ns;
+    }
 
-    if (abd_arena == NULL)
+    int64_t rem = 0;
+
+    /* 1. Hard perimeter - true system emergency. Smooth proportional ramp on
+     *    how deep we are into the buffer zone, netted against what's pending. */
+    if (critical_memory_state(buffer_zone, &rem)) {
+	const int64_t crit_floor = 100LL * 1024 * 1024;
+	const int64_t crit_cap = 200LL * 1024 * 1024;
+
+	int64_t depth = buffer_zone - rem;          /* 0 at edge, == zone at wall */
+	if (depth < 0)           depth = 0;
+	if (depth > buffer_zone) depth = buffer_zone;
+
+	int64_t target = crit_floor +
+	    ((crit_cap - crit_floor) * depth) / buffer_zone;
+
+	int64_t net = target - inflight_reduce;     /* only what's not on its way */
+	if (net < crit_floor)
+	    return (0);                             /* already covered - let it land */
+	if (net > crit_cap)
+	    net = crit_cap;
+
+	last_shrink_time = now;
+	inflight_reduce += net;
+	return (net);
+    }
+
+    if (prealloc_phase == PREALLOC_PHASE_ALLOC ||
+	prealloc_phase == PREALLOC_PHASE_IDLE)
 	return (0);
 
-    const int64_t mem_import =
-	(int64_t)abd_arena->vm_kstat.vk_mem_import.value.ui64;
-    const int64_t mem_inuse =
-	(int64_t)abd_arena->vm_kstat.vk_mem_inuse.value.ui64;
-  
-    const int64_t free_warm =
-	(mem_import > mem_inuse) ? (mem_import - mem_inuse) : 0;   
+    /* 2. Proportional overshoot reclaim (steady state). */
+    if (now < last_shrink_time + settle_ns)
+	return (0);
 
-    // 3. Calculate effective active allocations by discounting the unused warm memory.
-    // This stops the preallocation thread from generating false out-of-memory pressure at boot.
-    int64_t active_os_alloc = segkmem_total_mem_allocated - free_warm;
-    if (active_os_alloc < 0) {
+    const int64_t free_warm = abd_free_warm_bytes();
+    int64_t active_os_alloc = (int64_t)segkmem_total_mem_allocated - free_warm;
+    if (active_os_alloc < 0)
 	active_os_alloc = 0;
-    }
 
-    // 4. Evaluate whether active consumption has breached our safety perimeter
+    const int64_t safe_threshold = (int64_t)total_memory - buffer_zone;
+
     if (active_os_alloc > safe_threshold) {
-	// Calculate the exact number of bytes we have overshot the safe zone boundary
-	int64_t overshoot = active_os_alloc - safe_threshold;
+	const int64_t reap_floor = 10LL * 1024 * 1024;
+	const int64_t reap_cap = 50LL * 1024 * 1024;
+	const int64_t overshoot = active_os_alloc - safe_threshold;
 
-	// Define an aggressive baseline target (e.g., 150 MB) to replace the weak legacy 14 MB cap
-	int64_t aggressive_reap_base = 200LL * 1024 * 1024;
+	int64_t net = overshoot - inflight_reduce;
+	if (net < reap_floor)
+	    return (0);
+	if (net > reap_cap)
+	    net = reap_cap;
 
-	// Return whichever value is larger to ensure the ARC acts decisively to clear the bottleneck
-	return (overshoot > aggressive_reap_base) ? overshoot : aggressive_reap_base;
+	last_shrink_time = now;
+	inflight_reduce += net;
+	return (net);
     }
-    
+
     return (0);
 }
 
@@ -5058,6 +5121,7 @@ spl_abd_prealloc_thread(void *notused)
 	    segkmem_total_mem_allocated, total_memory));
 
 	dprintf("SPL: beginning spl_abd_prealloc_thread() loop\n");
+	prealloc_phase = PREALLOC_PHASE_ALLOC;
 
 	list_create(&abd_prealloc_list, sizeof (abd_prealloc_node_t), offsetof(abd_prealloc_node_t, node));
 
@@ -5077,12 +5141,14 @@ spl_abd_prealloc_thread(void *notused)
 		list_insert_tail(&abd_prealloc_list, node);
 	}
 
+	prealloc_phase = PREALLOC_PHASE_FREE;
 	while ((node = list_remove_head(&abd_prealloc_list)) != NULL) {
 		kmem_cache_free(abd_chunk_cache, node);
 	}
 
 	spl_abd_prealloc_thread_exit = FALSE;
 	dprintf("SPL: %s thread_exit\n", __func__);
+	prealloc_phase = PREALLOC_PHASE_DONE;
 
 	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "SPL: abd prealloc done segkmem_total_mem_allocated: %lld total_memory: %lld zfs_arc_max: %llu zfs_prealloc_percent: %d%\n",
 	    segkmem_total_mem_allocated, total_memory, zfs_arc_max, zfs_prealloc_percent));

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -4968,8 +4968,8 @@ spl_abd_prealloc_thread(void *notused)
 	spl_abd_prealloc_thread_exit = FALSE;
 	dprintf("SPL: %s thread_exit\n", __func__);
 
-	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "SPL: abd prealloc done segkmem_total_mem_allocated: %lld total_memory: %lld zfs_prealloc_percent: %d%\n",
-	    segkmem_total_mem_allocated, total_memory, zfs_abd_prealloc_percent));
+	KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "SPL: abd prealloc done segkmem_total_mem_allocated: %lld total_memory: %lld zfs_arc_max: %llu zfs_prealloc_percent: %d%\n",
+	    segkmem_total_mem_allocated, total_memory, zfs_arc_max, zfs_abd_prealloc_percent));
 	thread_exit();
 }
 

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -4304,7 +4304,10 @@ spl_free_set_pressure(int64_t new_p)
 		// and any spl_free_set_and_wait_pressure() threads
 		cv_broadcast(&spl_free_thread_cv);
 	}
-	spl_free_last_pressure = zfs_lbolt();
+	if (new_p > 0)
+		spl_free_last_pressure = zfs_lbolt();
+	else
+		spl_free_last_pressure = zfs_lbolt();
 }
 
 void
@@ -4480,6 +4483,7 @@ spl_free_thread()
 		    spl_vm_pressure_level != MAGIC_PRESSURE_UNAVAILABLE) {
 			/* there is pressure */
 			lowmem = true;
+			KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "spl_vm_pressure_level: %lu\n",spl_vm_pressure_level));
 			new_spl_free = -(2LL * PAGE_SIZE * spl_vm_pages_wanted);
 			if (spl_vm_pressure_level > 1) {
 				emergency_lowmem = true;
@@ -4534,6 +4538,7 @@ spl_free_thread()
 			int64_t old_pressure = spl_free_manual_pressure;
 			new_spl_free -= old_pressure * 2LL;
 			lowmem = true;
+			KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "spl_free_manual_pressure: %llu\n",spl_free_manual_pressure));
 			if (spl_free_fast_pressure) {
 				emergency_lowmem = true;
 				new_spl_free -= old_pressure * 4LL;
@@ -4631,6 +4636,7 @@ spl_free_thread()
 			new_spl_free += bminus;
 			lowmem = true;
 			emergency_lowmem = true;
+			KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "spl_vm_pages_wanted %lu\n", spl_vm_pages_wanted));
 			// atomic swaps to set these variables used in arc.c
 			int64_t previous_highest_pressure = 0;
 			int64_t new_p = -bminus;
@@ -4651,6 +4657,7 @@ spl_free_thread()
 			new_spl_free -= bytes_wanted;
 			if (reserve_low && !early_lots_free) {
 				lowmem = true;
+				KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "spl_vm_pages_wanted: %lu reserve_low: %lu early_lots_free: %lu\n", spl_vm_pages_wanted, reserve_low, early_lots_free));
 				if (recent_lowmem == 0) {
 					recent_lowmem = time_now;
 				}
@@ -4761,6 +4768,7 @@ spl_free_thread()
 			    real_total_memory) > 75) {
 				new_spl_free -= total_mem_used / 32;
 				lowmem = true;
+				KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "segkmem_total_mem_allocated: %llu real_total_memory: %llu\n", segkmem_total_mem_allocated, real_total_memory));
 			}
 		}
 
@@ -5393,8 +5401,8 @@ spl_kmem_thread_init(void)
 	(void) thread_create(NULL, 0, spl_free_thread, 0, 0, 0, 0, 92);
 	spl_free_thread_running = TRUE;
 
-	spl_event_thread_exit = FALSE;
-	(void) thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);
+	//spl_event_thread_exit = FALSE;
+	//(void) thread_create(NULL, 0, spl_event_thread, 0, 0, 0, 0, 92);
 
 	spl_abd_prealloc_thread_exit = FALSE;
 	(void) thread_create(NULL, 0, spl_abd_prealloc_thread, 0, 0, 0, 0, 92);

--- a/module/os/windows/spl/spl-kmem.c
+++ b/module/os/windows/spl/spl-kmem.c
@@ -4227,21 +4227,132 @@ kmem_cache_fini()
 int64_t
 spl_free_wrapper(void)
 {
+    if (zfs_prealloc_percent == 0)
 	return (spl_free);
+
+    extern vmem_t* abd_arena;
+
+    /*
+     * If abd_arena is not yet initialized, fall back to the standard
+     * spl_free path rather than returning 0 (which would block ARC growth).
+     */
+    if (abd_arena == NULL)
+	return (spl_free);
+
+    /*
+     * Read abd_cache vmem kstat counters.
+     *
+     * mem_import: total bytes committed from OS to abd_cache slabs.
+     *             This is fully counted in os_mem_alloc.
+     * mem_inuse:  bytes actively held by live ABD objects (ARC data).
+     * free_warm:  mem_import - mem_inuse
+     *             Memory OS has committed, sitting free in the slab.
+     *             ARC can consume this at zero additional OS cost.
+     *             os_mem_alloc counts this as "used" — that is wrong
+     *             from ARC's perspective, so we discount it.
+     */
+    const int64_t mem_import =
+	(int64_t)abd_arena->vm_kstat.vk_mem_import.value.ui64;
+    const int64_t mem_inuse =
+	(int64_t)abd_arena->vm_kstat.vk_mem_inuse.value.ui64;
+
+    /*
+     * Sanity: mem_import should always be >= mem_inuse.
+     * Guard against transient races where counters are momentarily
+     * inconsistent (both updated non-atomically by vmem internals).
+     */
+    const int64_t free_warm =
+	(mem_import > mem_inuse) ? (mem_import - mem_inuse) : 0;
+
+    /*
+     * Effective OS pressure = what os_mem_alloc reports, minus the
+     * portion that is free in the slab (pre-paid by prealloc, costs
+     * nothing for ARC to consume).
+     *
+     * os_mem_alloc is extern'd from spl-vmem.c — same source spl_free uses.
+     */
+    const int64_t effective_os_alloc =
+	segkmem_total_mem_allocated - free_warm;
+
+    /*
+     * OS headroom: how much more can we allocate before hitting the
+     * system memory ceiling. Cast total_memory to int64_t BEFORE
+     * multiplying to avoid uint64_t overflow.
+     */
+    const int64_t memory_limit =
+	((int64_t)total_memory * 95) / 100;   /* 95% of physical RAM */
+
+    const int64_t os_headroom = memory_limit - effective_os_alloc;
+
+    /*
+     * ARC headroom: how far below arc_max is arc_c right now.
+     * ARC must never grow past arc_max regardless of OS headroom.
+     */
+    const int64_t arc_headroom =
+	zfs_arc_max - arc_target_size();
+
+    /*
+     * Available = minimum of both constraints.
+     * Clamp to spl_free as a lower bound so we never report
+     * more freedom than the base (non-prealloc) path would.
+     */
+    const int64_t available = MIN(os_headroom, arc_headroom);
+    
+    return available;
+}
+
+bool critical_memory_state(int64_t bufferzone)
+{
+    int64_t remainder = (total_memory - segkmem_total_mem_allocated);
+    if (remainder < bufferzone) return 1;
+    return 0;
 }
 
 // this is intended to substitute for kmem_avail() in arc.c
 // when arc_reclaim_thread() calls spl_free_set_pressure(0);
 int64_t
 spl_free_manual_pressure_wrapper(void)
-{      	
-    if (arc_target_size() >= ((zfs_arc_max * 95ULL) / 100ULL)) {
-	return (spl_free_manual_pressure); 
+{   
+    int64_t five_percent = (total_memory * 5) / 100;
+    int64_t five_hundred_mb = 500LL * 1024 * 1024; // 500 MB in bytes
+
+    int64_t buffer_zone = MIN(five_hundred_mb, five_percent);
+    int64_t safe_threshold = total_memory - buffer_zone;
+
+    if (critical_memory_state(buffer_zone)) return 500LL * 1024 * 1024;
+
+    extern vmem_t* abd_arena;
+
+    if (abd_arena == NULL)
+	return (0);
+
+    const int64_t mem_import =
+	(int64_t)abd_arena->vm_kstat.vk_mem_import.value.ui64;
+    const int64_t mem_inuse =
+	(int64_t)abd_arena->vm_kstat.vk_mem_inuse.value.ui64;
+  
+    const int64_t free_warm =
+	(mem_import > mem_inuse) ? (mem_import - mem_inuse) : 0;   
+
+    // 3. Calculate effective active allocations by discounting the unused warm memory.
+    // This stops the preallocation thread from generating false out-of-memory pressure at boot.
+    int64_t active_os_alloc = segkmem_total_mem_allocated - free_warm;
+    if (active_os_alloc < 0) {
+	active_os_alloc = 0;
     }
-    else if ((segkmem_total_mem_allocated * 100ULL) / total_memory > 95) {
-	return (spl_free_manual_pressure);
+
+    // 4. Evaluate whether active consumption has breached our safety perimeter
+    if (active_os_alloc > safe_threshold) {
+	// Calculate the exact number of bytes we have overshot the safe zone boundary
+	int64_t overshoot = active_os_alloc - safe_threshold;
+
+	// Define an aggressive baseline target (e.g., 150 MB) to replace the weak legacy 14 MB cap
+	int64_t aggressive_reap_base = 200LL * 1024 * 1024;
+
+	// Return whichever value is larger to ensure the ARC acts decisively to clear the bottleneck
+	return (overshoot > aggressive_reap_base) ? overshoot : aggressive_reap_base;
     }
-        
+    
     return (0);
 }
 

--- a/module/os/windows/spl/spl-thread.c
+++ b/module/os/windows/spl/spl-thread.c
@@ -39,7 +39,78 @@
 
 uint64_t zfs_threads = 0;
 
-kthread_t *
+
+kthread_t*
+spl_thread_create(
+    caddr_t     stk,
+    size_t      stksize,
+    void        (*proc)(void*),
+    void* arg,
+    size_t      len,
+    int state,
+#ifdef SPL_DEBUG_THREAD
+    char* filename,
+    int line,
+#endif
+    pri_t       pri)
+{
+    NTSTATUS    status;
+    HANDLE      hThread = NULL;
+    PETHREAD    eThread = NULL;
+
+#ifdef SPL_DEBUG_THREAD
+    dprintf("Start thread pri %d\n", pri);
+#endif
+
+    status = PsCreateSystemThread(
+	&hThread,
+	THREAD_ALL_ACCESS,
+	NULL,
+	NULL,
+	NULL,
+	proc,
+	arg);
+
+    if (!NT_SUCCESS(status))
+	return NULL;
+
+    /* Convert HANDLE ETHREAD */
+    status = ObReferenceObjectByHandle(
+	hThread,
+	THREAD_ALL_ACCESS,
+	*PsThreadType,
+	KernelMode,
+	(PVOID*)&eThread,
+	NULL);
+
+    /* We no longer need the handle */
+    ZwClose(hThread);
+
+    if (!NT_SUCCESS(status))
+	return NULL;
+
+    /* Clamp priority to safe Windows range */
+    KPRIORITY newPri = (KPRIORITY)pri;
+
+    if (newPri > maxclsyspri)
+	newPri = maxclsyspri;
+
+    if (newPri < minclsyspri)
+	newPri = minclsyspri;
+
+    /* Set absolute priority */
+    KeSetPriorityThread((PKTHREAD)eThread, newPri);
+
+#ifdef SPL_DEBUG_THREAD
+    dprintf("Thread created with priority %d\n", newPri);
+#endif
+
+    atomic_inc_64(&zfs_threads);
+
+    return (kthread_t*)eThread;
+}
+
+/*kthread_t*
 spl_thread_create(
     caddr_t	stk,
     size_t	stksize,
@@ -72,12 +143,7 @@ spl_thread_create(
 	if (result != STATUS_SUCCESS)
 		return (NULL);
 
-	/*
-	 * Improve the priority when asked to do so
-	 * Thread priorities range from 0 to 31, where 0 is the lowest
-	 * priority and 31 is the highest
-	 */
-
+	
 	if (pri > minclsyspri) {
 		// thread_precedence_policy_data_t policy;
 		// policy.importance = pri - minclsyspri;
@@ -102,7 +168,7 @@ spl_thread_create(
 	ObDereferenceObject(eThread);
 	ZwClose(thread);
 	return ((kthread_t *)eThread);
-}
+}*/
 
 kthread_t *
 spl_current_thread(void)

--- a/module/os/windows/spl/spl-vmem.c
+++ b/module/os/windows/spl/spl-vmem.c
@@ -1737,10 +1737,7 @@ vmem_xfree(vmem_t *vmp, void *vaddr, size_t size)
 	// don;t want to do this unless we are near the arc limit
 	boolean_t skip_sfree = true;
 	if (segkmem_total_mem_allocated >
-		(zfs_arc_max * 100) / 100) {
-		KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
-		       	"vmem_xfree: skip source free segkmem_total_mem_allocated: %llu zfs_arc_max: %llu\n",
-			segkmem_total_mem_allocated, zfs_arc_max));
+		(zfs_arc_max * 102) / 100) {
 		skip_sfree = false;
         }
 

--- a/module/os/windows/spl/spl-vmem.c
+++ b/module/os/windows/spl/spl-vmem.c
@@ -1737,7 +1737,7 @@ vmem_xfree(vmem_t *vmp, void *vaddr, size_t size)
 	// don;t want to do this unless we are near the arc limit
 	boolean_t skip_sfree = true;
 	if (segkmem_total_mem_allocated >
-		(zfs_arc_max * 90) / 100) {
+		(zfs_arc_max * 100) / 100) {
 		KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
 		       	"vmem_xfree: skip source free segkmem_total_mem_allocated: %llu zfs_arc_max: %llu\n",
 			segkmem_total_mem_allocated, zfs_arc_max));

--- a/module/os/windows/spl/spl-vmem.c
+++ b/module/os/windows/spl/spl-vmem.c
@@ -448,6 +448,7 @@ uint64_t spl_frag_walk_cnt = 0;
 extern void spl_free_set_emergency_pressure(int64_t p);
 extern uint64_t segkmem_total_mem_allocated;
 extern uint64_t total_memory;
+extern uint64_t zfs_arc_max;
 
 /*
  * Get a vmem_seg_t from the global segfree list.
@@ -1732,12 +1733,23 @@ vmem_xfree(vmem_t *vmp, void *vaddr, size_t size)
 		vsp = vprev;
 	}
 
+	// calling vm_source_free will free the memory to windows, we
+	// don;t want to do this unless we are near the arc limit
+	boolean_t skip_sfree = true;
+	if (segkmem_total_mem_allocated >
+		(zfs_arc_max * 90) / 100) {
+		KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL,
+		       	"vmem_xfree: skip source free segkmem_total_mem_allocated: %llu zfs_arc_max: %llu\n",
+			segkmem_total_mem_allocated, zfs_arc_max));
+		skip_sfree = false;
+        }
+
 	/*
 	 * If the entire span is free, return it to the source.
 	 */
 	if (vsp->vs_aprev->vs_import && vmp->vm_source_free != NULL &&
 	    vsp->vs_aprev->vs_type == VMEM_SPAN &&
-	    vsp->vs_anext->vs_type == VMEM_SPAN) {
+	    vsp->vs_anext->vs_type == VMEM_SPAN && !skip_sfree) {
 		vaddr = (void *)vsp->vs_start;
 		size = VS_SIZE(vsp);
 		ASSERT(size == VS_SIZE(vsp->vs_aprev));

--- a/module/os/windows/spl/spl-vmem.c
+++ b/module/os/windows/spl/spl-vmem.c
@@ -449,6 +449,7 @@ extern void spl_free_set_emergency_pressure(int64_t p);
 extern uint64_t segkmem_total_mem_allocated;
 extern uint64_t total_memory;
 extern uint64_t zfs_arc_max;
+extern int zfs_prealloc_percent;
 
 /*
  * Get a vmem_seg_t from the global segfree list.
@@ -1734,19 +1735,22 @@ vmem_xfree(vmem_t *vmp, void *vaddr, size_t size)
 	}
 
 	// calling vm_source_free will free the memory to windows, we
-	// don;t want to do this unless we are near the arc limit
-	boolean_t skip_sfree = true;
-	if (segkmem_total_mem_allocated >
-		(zfs_arc_max * 102) / 100) {
-		skip_sfree = false;
-        }
+	// don't want to do this unless we are crossing the arc limit when
+	// zfs_prealloc_percent is enabled.
+	boolean_t allow_vm_source_free = true;
+	if (zfs_prealloc_percent) {
+		if (segkmem_total_mem_allocated <
+			(zfs_arc_max * 102) / 100) {
+			allow_vm_source_free = false;
+		}
+	}
 
 	/*
 	 * If the entire span is free, return it to the source.
 	 */
 	if (vsp->vs_aprev->vs_import && vmp->vm_source_free != NULL &&
 	    vsp->vs_aprev->vs_type == VMEM_SPAN &&
-	    vsp->vs_anext->vs_type == VMEM_SPAN && !skip_sfree) {
+	    vsp->vs_anext->vs_type == VMEM_SPAN && allow_vm_source_free) {
 		vaddr = (void *)vsp->vs_start;
 		size = VS_SIZE(vsp);
 		ASSERT(size == VS_SIZE(vsp->vs_aprev));

--- a/module/os/windows/spl/spl-windows.c
+++ b/module/os/windows/spl/spl-windows.c
@@ -53,12 +53,14 @@ volatile unsigned int vm_page_speculative_count = 5500;
 
 uint64_t spl_GetPhysMem(void);
 uint64_t spl_GetZfsTotalMemory(PUNICODE_STRING RegistryPath);
+uint64_t spl_getZfsPreallocSize(PUNICODE_STRING RegistryPath);
 
 #include <sys/types.h>
 #include <Trace.h>
 
 // Size in bytes of the memory allocated in seg_kmem
 extern uint64_t	segkmem_total_mem_allocated;
+extern int zfs_prealloc_percent;
 #define	MAXHOSTNAMELEN 64
 extern char hostname[MAXHOSTNAMELEN];
 
@@ -528,6 +530,9 @@ spl_start(PUNICODE_STRING RegistryPath)
 	spl_mutex_subsystem_init();
 	spl_kmem_init(total_memory);
 
+	// lets get the registry value now, because the zfs loads the registry little later
+	zfs_prealloc_percent = spl_getZfsPreallocSize(RegistryPath);
+
 	spl_vnode_init();
 	spl_kmem_thread_init();
 	spl_kmem_mp_init();
@@ -741,6 +746,94 @@ spl_GetZfsTotalMemory(PUNICODE_STRING RegistryPath)
 				newvalue = *(uint64_t *)((uint8_t *)regBuffer
 				    + regBuffer->DataOffset);
 				dprintf("%s: zfs_total_memory_limit is set to:"
+				    " %llu\n", __func__, newvalue);
+			}
+			break;
+		}
+		ExFreePool(regBuffer);
+		regBuffer = NULL;
+	}
+
+	if (regBuffer)
+		ExFreePool(regBuffer);
+
+	ZwClose(h);
+	return (newvalue);
+}
+
+uint64_t
+spl_getZfsPreallocSize(PUNICODE_STRING RegistryPath)
+{
+	OBJECT_ATTRIBUTES		ObjectAttributes;
+	HANDLE				h;
+	NTSTATUS			status;
+	uint64_t			newvalue = 0;
+
+	InitializeObjectAttributes(&ObjectAttributes,
+	    RegistryPath,
+	    OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+	    NULL,
+	    NULL);
+
+	status = ZwOpenKey(&h, // KeyHandle
+	    KEY_ALL_ACCESS, // DesiredAccess
+	    &ObjectAttributes); // ObjectAttributes
+
+	if (!NT_SUCCESS(status)) {
+		dprintf("%s: Unable to open Registry %wZ: 0x%x. "
+		    "Going with defaults.\n", __func__, RegistryPath, status);
+		return (0);
+	}
+
+	ULONG index = 0;
+	ULONG length = 0;
+	PKEY_VALUE_FULL_INFORMATION    regBuffer = NULL;
+
+	for (index = 0; status != STATUS_NO_MORE_ENTRIES; index++) {
+		// Get the buffer size necessary
+		status = ZwEnumerateValueKey(h, index, KeyValueFullInformation,
+		    NULL, 0, &length);
+
+		if ((status != STATUS_BUFFER_TOO_SMALL) &&
+		    (status != STATUS_BUFFER_OVERFLOW))
+			break; // Something is wrong - or we finished
+
+		// Allocate space to hold
+		regBuffer = (PKEY_VALUE_FULL_INFORMATION)ExAllocatePoolWithTag(
+		    NonPagedPoolNx, length, 'zfsr');
+
+		if (regBuffer == NULL)
+			break;
+
+		status = ZwEnumerateValueKey(h, index, KeyValueFullInformation,
+		    regBuffer, length, &length);
+		if (!NT_SUCCESS(status)) {
+			break;
+		}
+		// Convert name to straight ascii so we compare with kstat
+		ULONG outlen = 0;
+		char keyname[KSTAT_STRLEN + 1] = { 0 };
+		status = RtlUnicodeToUTF8N(keyname, KSTAT_STRLEN, &outlen,
+		    regBuffer->Name, regBuffer->NameLength);
+
+		// Conversion failed? move along..
+		if (status != STATUS_SUCCESS && status
+		    != STATUS_SOME_NOT_MAPPED)
+			break;
+
+		// Output string is only null terminated if input is,
+		// so do so now.
+		keyname[outlen] = 0;
+		if (strcasecmp("zfs_prealloc_percent", keyname) == 0) {
+			if (regBuffer->Type != REG_DWORD ||
+			    regBuffer->DataLength != sizeof (uint32_t)) {
+				dprintf("%s: registry '%s' did not match. "
+				    "Type needs to be REG_QWORD. (8 bytes)\n",
+				    __func__, keyname);
+			} else {
+				newvalue = *(uint32_t *)((uint8_t *)regBuffer
+				    + regBuffer->DataOffset);
+				dprintf("%s: zfs_prealloc_percent is set to:"
 				    " %llu\n", __func__, newvalue);
 			}
 			break;

--- a/module/os/windows/spl/spl-windows.c
+++ b/module/os/windows/spl/spl-windows.c
@@ -531,7 +531,9 @@ spl_start(PUNICODE_STRING RegistryPath)
 	spl_kmem_init(total_memory);
 
 	// lets get the registry value now, because the zfs loads the registry little later
-	zfs_prealloc_percent = spl_getZfsPreallocSize(RegistryPath);
+	int reg_val = spl_getZfsPreallocSize(RegistryPath);
+	if (reg_val != 0)
+	    zfs_prealloc_percent = reg_val;
 
 	spl_vnode_init();
 	spl_kmem_thread_init();

--- a/module/os/windows/zfs/abd_os.c
+++ b/module/os/windows/zfs/abd_os.c
@@ -87,7 +87,7 @@ struct {
  * will cause the machine to panic if you change it and try to access the data
  * within a scattered ABD.
  */
-size_t zfs_abd_chunk_size = 65536;
+size_t zfs_abd_chunk_size = 4096;
 
 kmem_cache_t *abd_chunk_cache;
 static kstat_t *abd_ksp;

--- a/module/os/windows/zfs/abd_os.c
+++ b/module/os/windows/zfs/abd_os.c
@@ -87,7 +87,7 @@ struct {
  * will cause the machine to panic if you change it and try to access the data
  * within a scattered ABD.
  */
-size_t zfs_abd_chunk_size = 4096;
+size_t zfs_abd_chunk_size = 65536;
 
 kmem_cache_t *abd_chunk_cache;
 static kstat_t *abd_ksp;

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -59,6 +59,7 @@
 #include <sys/kstat_windows.h>
 
 extern arc_stats_t arc_stats;
+extern uint64_t zfs_arc_max;
 
 static kmutex_t			arc_reclaim_lock;
 static kcondvar_t		arc_reclaim_thread_cv;
@@ -127,7 +128,7 @@ arc_free_memory(void)
 int64_t
 arc_available_memory(void)
 {
-	return (arc_free_memory() - arc_sys_free);
+	return (zfs_arc_max - aggsum_value(&arc_sums.arcstat_size));
 }
 
 int
@@ -137,8 +138,7 @@ arc_memory_throttle(spa_t *spa, uint64_t reserve, uint64_t txg)
 	/* possibly wake up arc reclaim thread */
 
 	if (arc_reclaim_in_loop == B_FALSE) {
-		if (spl_free_manual_pressure_wrapper() != 0 ||
-		    !spl_minimal_physmem_p() ||
+		if (!spl_minimal_physmem_p() ||
 		    arc_reclaim_needed()) {
 			cv_signal(&arc_reclaim_thread_cv);
 			kpreempt(KPREEMPT_SYNC);
@@ -798,7 +798,7 @@ arc_prune_async(int64_t adjust)
 int64_t
 arc_available_memory(void)
 {
-	return (arc_free_memory() - arc_sys_free);
+	return (zfs_arc_max - aggsum_value(&arc_sums.arcstat_size));  
 }
 
 int

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -697,6 +697,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		    ks->arc_zfs_arc_average_blocksize.value.ui64;
 		zvol_threads = ks->zvol_io_threads.value.ui32;
 		zfs_prealloc_percent = ks->zfs_prealloc_percent.value.ui32;
+		zfs_adc_target_sync_pct = ks->zfs_adc_target_sync_pct.value.ui32;
 
 #ifdef _KERNEL
 		if (ks->zfs_total_memory_limit.value.ui64 > total_memory &&
@@ -733,6 +734,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		    zfs_arc_average_blocksize;
 		ks->zvol_io_threads.value.ui32 = zvol_threads;
 		ks->zfs_prealloc_percent.value.ui32 = zfs_prealloc_percent;
+		ks->zfs_adc_target_sync_pct.value.ui32 = zfs_adc_target_sync_pct;
 
 #ifdef _KERNEL
 		ks->zfs_total_memory_limit.value.ui64 = total_memory;

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -696,6 +696,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		zfs_arc_average_blocksize =
 		    ks->arc_zfs_arc_average_blocksize.value.ui64;
 		zvol_threads = ks->zvol_io_threads.value.ui32;
+		zfs_abd_prealloc_percent = ks->zfs_abd_prealloc_percent.value.ui32;
 
 #ifdef _KERNEL
 		if (ks->zfs_total_memory_limit.value.ui64 > total_memory &&
@@ -731,6 +732,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		ks->arc_zfs_arc_average_blocksize.value.ui64 =
 		    zfs_arc_average_blocksize;
 		ks->zvol_io_threads.value.ui32 = zvol_threads;
+		ks->zfs_abd_prealloc_percent.value.ui32 = zfs_abd_prealloc_percent;
 
 #ifdef _KERNEL
 		ks->zfs_total_memory_limit.value.ui64 = total_memory;

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -128,7 +128,7 @@ arc_free_memory(void)
 int64_t
 arc_available_memory(void)
 {
-	return (zfs_arc_max - aggsum_value(&arc_sums.arcstat_size));
+	return (arc_free_memory() - arc_sys_free);
 }
 
 int64_t
@@ -806,7 +806,7 @@ arc_prune_async(int64_t adjust)
 int64_t
 arc_available_memory(void)
 {
-	return (zfs_arc_max - aggsum_value(&arc_sums.arcstat_size));  
+	return (arc_free_memory() - arc_sys_free);
 }
 
 int

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -696,7 +696,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		zfs_arc_average_blocksize =
 		    ks->arc_zfs_arc_average_blocksize.value.ui64;
 		zvol_threads = ks->zvol_io_threads.value.ui32;
-		zfs_abd_prealloc_percent = ks->zfs_abd_prealloc_percent.value.ui32;
+		zfs_prealloc_percent = ks->zfs_prealloc_percent.value.ui32;
 
 #ifdef _KERNEL
 		if (ks->zfs_total_memory_limit.value.ui64 > total_memory &&
@@ -732,7 +732,7 @@ arc_kstat_update_windows(kstat_t *ksp, int rw)
 		ks->arc_zfs_arc_average_blocksize.value.ui64 =
 		    zfs_arc_average_blocksize;
 		ks->zvol_io_threads.value.ui32 = zvol_threads;
-		ks->zfs_abd_prealloc_percent.value.ui32 = zfs_abd_prealloc_percent;
+		ks->zfs_prealloc_percent.value.ui32 = zfs_prealloc_percent;
 
 #ifdef _KERNEL
 		ks->zfs_total_memory_limit.value.ui64 = total_memory;

--- a/module/os/windows/zfs/arc_os.c
+++ b/module/os/windows/zfs/arc_os.c
@@ -131,6 +131,12 @@ arc_available_memory(void)
 	return (zfs_arc_max - aggsum_value(&arc_sums.arcstat_size));
 }
 
+int64_t
+arc_target_size(void)
+{
+    return (arc_c);
+}
+
 int
 arc_memory_throttle(spa_t *spa, uint64_t reserve, uint64_t txg)
 {
@@ -138,7 +144,7 @@ arc_memory_throttle(spa_t *spa, uint64_t reserve, uint64_t txg)
 	/* possibly wake up arc reclaim thread */
 
 	if (arc_reclaim_in_loop == B_FALSE) {
-		if (!spl_minimal_physmem_p() ||
+		if (spl_free_manual_pressure_wrapper() != 0 || !spl_minimal_physmem_p() ||
 		    arc_reclaim_needed()) {
 			cv_signal(&arc_reclaim_thread_cv);
 			kpreempt(KPREEMPT_SYNC);

--- a/module/os/windows/zfs/zfs_kstat_windows.c
+++ b/module/os/windows/zfs/zfs_kstat_windows.c
@@ -174,7 +174,7 @@ windows_kstat_t windows_kstat = {
 	{ "zfs_removal_suspend_progress",	KSTAT_DATA_INT32 },
 	{ "cpu_avx_supported",			KSTAT_DATA_UINT32 },
 	{ "zvol_io_threads",			KSTAT_DATA_UINT32 },
-	{ "zfs_abd_prealloc_percent",		KSTAT_DATA_UINT32 },
+	{ "zfs_prealloc_percent",		KSTAT_DATA_UINT32 },
 };
 
 
@@ -384,8 +384,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->zfs_removal_suspend_progress.value.i32;
 		cpu_avx_supported =
 		    ks->cpu_avx_supported.value.ui32;
-		zfs_abd_prealloc_percent =
-		    ks->zfs_abd_prealloc_percent.value.ui32;
+		zfs_prealloc_percent =
+		    ks->zfs_prealloc_percent.value.ui32;
 	} else {
 
 		/* kstat READ */
@@ -576,8 +576,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    cpu_avx_supported;
 		ks->zvol_io_threads.value.ui32 =
 		    zvol_threads;
-		ks->zfs_abd_prealloc_percent.value.ui32 =
-		    zfs_abd_prealloc_percent;
+		ks->zfs_prealloc_percent.value.ui32 =
+		    zfs_prealloc_percent;
 	}
 	arc_kstat_update_windows(ksp, rw);
 	return (0);

--- a/module/os/windows/zfs/zfs_kstat_windows.c
+++ b/module/os/windows/zfs/zfs_kstat_windows.c
@@ -173,7 +173,8 @@ windows_kstat_t windows_kstat = {
 	{ "zfs_total_memory_limit",		KSTAT_DATA_UINT64 },
 	{ "zfs_removal_suspend_progress",	KSTAT_DATA_INT32 },
 	{ "cpu_avx_supported",			KSTAT_DATA_UINT32 },
-	{ "zvol_io_threads",			KSTAT_DATA_UINT32 }
+	{ "zvol_io_threads",			KSTAT_DATA_UINT32 },
+	{ "zfs_abd_prealloc_percent",		KSTAT_DATA_UINT32 },
 };
 
 
@@ -383,6 +384,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->zfs_removal_suspend_progress.value.i32;
 		cpu_avx_supported =
 		    ks->cpu_avx_supported.value.ui32;
+		zfs_abd_prealloc_percent =
+		    ks->zfs_abd_prealloc_percent.value.ui32;
 	} else {
 
 		/* kstat READ */
@@ -573,6 +576,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    cpu_avx_supported;
 		ks->zvol_io_threads.value.ui32 =
 		    zvol_threads;
+		ks->zfs_abd_prealloc_percent.value.ui32 =
+		    zfs_abd_prealloc_percent;
 	}
 	arc_kstat_update_windows(ksp, rw);
 	return (0);

--- a/module/os/windows/zfs/zfs_kstat_windows.c
+++ b/module/os/windows/zfs/zfs_kstat_windows.c
@@ -113,6 +113,7 @@ windows_kstat_t windows_kstat = {
 	{"spa_mode_global",				KSTAT_DATA_INT64  },
 	{"zfs_flags",					KSTAT_DATA_INT64  },
 	{"zfs_txg_timeout",				KSTAT_DATA_INT64  },
+	{"zfs_adc_enable",				KSTAT_DATA_INT64  },
 	{"zfs_vdev_cache_max",			KSTAT_DATA_INT64  },
 	{"zfs_vdev_cache_size",			KSTAT_DATA_INT64  },
 	{"zfs_vdev_cache_bshift",		KSTAT_DATA_INT64  },
@@ -175,6 +176,7 @@ windows_kstat_t windows_kstat = {
 	{ "cpu_avx_supported",			KSTAT_DATA_UINT32 },
 	{ "zvol_io_threads",			KSTAT_DATA_UINT32 },
 	{ "zfs_prealloc_percent",		KSTAT_DATA_UINT32 },
+	{ "zfs_adc_target_sync_pct",		KSTAT_DATA_UINT32 },
 };
 
 
@@ -291,6 +293,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->zfs_flags.value.i64;
 		zfs_txg_timeout =
 		    ks->zfs_txg_timeout.value.i64;
+		zfs_adc_enable =
+		    ks->zfs_adc_enable.value.i64;
 		zfs_vdev_cache_max =
 		    ks->zfs_vdev_cache_max.value.i64;
 		zfs_vdev_cache_size =
@@ -386,6 +390,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    ks->cpu_avx_supported.value.ui32;
 		zfs_prealloc_percent =
 		    ks->zfs_prealloc_percent.value.ui32;
+		zfs_adc_target_sync_pct =
+		    ks->zfs_adc_target_sync_pct.value.ui32;
 	} else {
 
 		/* kstat READ */
@@ -485,6 +491,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    zfs_flags;
 		ks->zfs_txg_timeout.value.i64 =
 		    zfs_txg_timeout;
+		ks->zfs_adc_enable.value.i64 =
+		    zfs_adc_enable;
 		ks->zfs_vdev_cache_max.value.i64 =
 		    zfs_vdev_cache_max;
 		ks->zfs_vdev_cache_size.value.i64 =
@@ -578,6 +586,8 @@ windows_kstat_update(kstat_t *ksp, int rw)
 		    zvol_threads;
 		ks->zfs_prealloc_percent.value.ui32 =
 		    zfs_prealloc_percent;
+		ks->zfs_adc_target_sync_pct.value.ui32 =
+		    zfs_adc_target_sync_pct;		
 	}
 	arc_kstat_update_windows(ksp, rw);
 	return (0);

--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -46,7 +46,7 @@ unsigned int zvol_request_sync = 0;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
 int zvol_threads = 0;
-int zfs_abd_prealloc_percent = 10;
+int zfs_prealloc_percent = 0;
 
 taskq_t *zvol_taskq;
 

--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -46,7 +46,7 @@ unsigned int zvol_request_sync = 0;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
 int zvol_threads = 0;
-int zfs_prealloc_percent = 0;
+int zfs_prealloc_percent = 100;
 
 taskq_t *zvol_taskq;
 

--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -46,7 +46,7 @@ unsigned int zvol_request_sync = 0;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
 int zvol_threads = 0;
-int zfs_prealloc_percent = 100;
+int zfs_prealloc_percent = 90;
 
 taskq_t *zvol_taskq;
 

--- a/module/os/windows/zfs/zvol_os.c
+++ b/module/os/windows/zfs/zvol_os.c
@@ -46,6 +46,7 @@ unsigned int zvol_request_sync = 0;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
 int zvol_threads = 0;
+int zfs_abd_prealloc_percent = 10;
 
 taskq_t *zvol_taskq;
 

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -462,6 +462,7 @@ int zfs_arc_meta_prune = 10000;
 int zfs_arc_meta_strategy = ARC_STRATEGY_META_BALANCED;
 int zfs_arc_meta_adjust_restarts = 4096;
 int zfs_arc_lotsfree_percent = 10;
+uint64_t dirty_ceil_bytes;
 
 /* The 6 states: */
 arc_state_t ARC_anon;
@@ -7998,6 +7999,8 @@ arc_init(void)
 		zfs_dirty_data_max = MIN(zfs_dirty_data_max,
 		    zfs_dirty_data_max_max);
 	}
+
+	dirty_ceil_bytes = zfs_dirty_data_max;
 }
 
 void

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -126,7 +126,6 @@ dynamic_dirty_data_stats_t dynamic_dirty_data_stats = {
     { "spa_sync_time",	KSTAT_DATA_INT64 },
     { "data_flushed_per_sync",	KSTAT_DATA_UINT64 },
     { "total_dirty_data",	KSTAT_DATA_UINT64 },
-
 };
 /*
  * Target spa_sync duration as a fraction of zfs_txg_timeout.
@@ -208,7 +207,7 @@ dynamic_dirty_data_kstat_update(kstat_t* ksp, int rw) {
 static inline clock_t
 adc_ema(clock_t prev, clock_t sample, uint_t alpha_pct)
 {
-    return (prev + (clock_t)(((int64_t)sample - prev)
+    return (prev + (clock_t)(((int64_t)sample - (int64_t)prev)
 	* alpha_pct / 100));
 }
 
@@ -245,6 +244,25 @@ adc_init(txg_adc_t* adc, clock_t target_ticks)
     }
 }
 
+void
+adc_fini(void)
+{
+    if (dd_ksp != NULL) {
+	kstat_delete(dd_ksp);
+	dd_ksp = NULL;
+    }
+
+    /*
+     * Zero the shadow globals so a subsequent kstat read
+     * before the next adc_init() returns 0 rather than
+     * stale values from the previous pool.
+     */
+    kstat_adc_target = 0;
+    kstat_spa_sync_time = 0;
+    kstat_data_flushed_per_sync = 0;
+    kstat_total_dirty_data = 0;
+}
+
 /*
  * adc_update — core PID + dirty_max adjustment.
  *
@@ -268,10 +286,12 @@ adc_update(txg_adc_t* adc, uint64_t txg,
     int64_t  adjustment;    /* byte delta for dirty_max            */
     uint64_t cur, proposed, next;
 
-    kstat_adc_target = (long)(((uint64_t)target_ticks * 1000ULL) / hz);
-    kstat_spa_sync_time = (long)(((uint64_t)raw_delta * 1000ULL) / hz);
+    kstat_adc_target = (long)(((int64_t)target_ticks * 1000ULL) / hz);
+    kstat_spa_sync_time = (long)(((int64_t)raw_delta * 1000ULL) / hz);
     kstat_data_flushed_per_sync = data_flushed;
     kstat_total_dirty_data = total_dirty;
+
+    if (data_flushed < DIRTY_FLOOR_BYTES) return;
 
     adc->adc_n_syncs++;
 
@@ -378,14 +398,14 @@ adc_update(txg_adc_t* adc, uint64_t txg,
 	zfs_dirty_data_max = next;
 	adc->adc_last_txg = txg;
 	if (next > cur) adc->adc_n_raised++;
-	else            adc->adc_n_lowered++;
+	else adc->adc_n_lowered++;
 
 	zfs_dbgmsg("txg_adc txg=%llu ema_delta=%ldms target=%ldms "
 	    "err=%lld P=%lld I=%lld D=%lld "
 	    "dirty_max %lluMB→%lluMB",
 	    (u_longlong_t)txg,
-	    (long)(((uint64_t)adc->adc_ema_delta * 1000ULL) / hz),
-	    (long)(((uint64_t)target_ticks * 1000ULL) / hz),
+	    (long)(((int64_t)adc->adc_ema_delta * 1000ULL) / hz),
+	    (long)(((int64_t)target_ticks * 1000ULL) / hz),
 	    (longlong_t)error,
 	    (longlong_t)p_term,
 	    (longlong_t)i_term,
@@ -866,8 +886,12 @@ txg_sync_thread(void *arg)
 			txg_thread_wait(tx, &cpr, &tx->tx_quiesce_done_cv, 0);
 		}
 
-		if (tx->tx_exiting)
+		if (tx->tx_exiting) {
+		    /* ADC: clean up kstat before thread exits */
+		    if (zfs_adc_enable)
+			adc_fini();
 		    txg_thread_exit(tx, &cpr, &tx->tx_sync_thread);
+		}
 
 		/*
 		 * Consume the quiesced txg which has been handed off to

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -34,6 +34,7 @@
 #include <sys/zil.h>
 #include <sys/callb.h>
 #include <sys/trace_zfs.h>
+#include<sys/kstat.h>
 
 /*
  * ZFS Transaction Groups
@@ -114,8 +115,17 @@ static void txg_quiesce_thread(void *arg);
 int zfs_txg_timeout = 1;	/* max seconds worth of delta per txg */
 
 #define DIRTY_FLOOR_BYTES       (153ULL << 20)
-#define DIRTY_CEIL_BYTES        (4ULL << 30)
+
+/*
+ * Target spa_sync duration as a fraction of zfs_txg_timeout.
+ * 75 = target 75% of timeout. This headroom allows for burst
+ * without immediately hitting throttle.
+ *
+ * Lower → more headroom, lower peak throughput
+ * Higher → more throughput, less burst tolerance
+ */
 uint_t zfs_adc_target_sync_pct = 75;
+
 /* PID gains, all scaled ×1000 to avoid floating point */
 int zfs_adc_kp = 200;   /* Proportional: main corrective force    */
 int zfs_adc_ki = 15;    /* Integral: eliminates steady-state bias  */
@@ -123,10 +133,17 @@ int zfs_adc_kd = 100;   /* Derivative: damping against oscillation */
 
 /* EMA smoothing window in TXG count */
 uint_t zfs_adc_ema_alpha_pct = 25;  /* 25% weight on new sample   */
+
 /* Minimum TXGs between dirty_max updates (anti-flapping) */
 uint_t zfs_adc_holdoff_txgs = 2;
+
 /* Master enable — 0 reverts to stock ZFS behavior instantly */
 int zfs_adc_enable = 1;
+
+/* ============================================================
+ * ADC STATE — one instance on the stack of txg_sync_thread
+ * No heap allocation, no lock needed (single-threaded use)
+ * ============================================================ */
 
 typedef struct {
     /* PID state */
@@ -149,6 +166,16 @@ typedef struct {
     int64_t     adc_last_d;         /* last D term for debug       */
 } txg_adc_t;
 
+/*
+ * adc_ema — Exponential moving average, integer arithmetic.
+ *
+ * new_ema = prev × (1 - α) + sample × α
+ *         = prev + (sample - prev) × alpha_pct / 100
+ *
+ * alpha_pct=25 means 25% weight on the newest sample, giving
+ * a smoothing time constant of ~3 TXGs — fast enough to track
+ * load changes, slow enough to ignore one-off scrub/snapshot bursts.
+ */
 static inline clock_t
 adc_ema(clock_t prev, clock_t sample, uint_t alpha_pct)
 {
@@ -156,13 +183,19 @@ adc_ema(clock_t prev, clock_t sample, uint_t alpha_pct)
 	* alpha_pct / 100));
 }
 
+/*
+ * adc_init — called once before the txg_sync_thread loop.
+ *
+ * Seeds the EMA at the target so the first TXG doesn't trigger
+ * an aggressive correction from a cold zero baseline.
+ */
 static void
 adc_init(txg_adc_t* adc, clock_t target_ticks)
 {    
     bzero(adc, sizeof(*adc));
 
     adc->adc_min_dirty = DIRTY_FLOOR_BYTES;
-    adc->adc_max_dirty = DIRTY_CEIL_BYTES;
+    adc->adc_max_dirty = dirty_ceil_bytes;
 
     /* Defensive: ensure min < max regardless of tunable misconfiguration */
     if (adc->adc_min_dirty >= adc->adc_max_dirty)
@@ -174,6 +207,17 @@ adc_init(txg_adc_t* adc, clock_t target_ticks)
     adc->adc_integral = 0;
 }
 
+/*
+ * adc_update — core PID + dirty_max adjustment.
+ *
+ * Called every TXG with the just-measured spa_sync duration.
+ * Modifies zfs_dirty_data_max in place.
+ *
+ * @adc:          controller state
+ * @txg:          current TXG id (for holdoff tracking)
+ * @raw_delta:    ddi_get_lbolt() delta from this spa_sync
+ * @target_ticks: desired spa_sync duration in lbolt ticks
+ */
 static void
 adc_update(txg_adc_t* adc, uint64_t txg,
     clock_t raw_delta, clock_t target_ticks)
@@ -725,15 +769,20 @@ txg_sync_thread(void *arg)
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 	clock_t start, delta;
+	/* ◄── ADC: declare controller state — stack allocated,
+	*      zero overhead when zfs_adc_enable == 0           */
 	txg_adc_t    adc;
 
 	(void) spl_fstrans_mark();
 	txg_thread_enter(tx, &cpr);
 
 	start = delta = 0;
+	/* ◄── ADC: compute target once; recomputed if timeout changes.
+	*    target = zfs_txg_timeout × target_pct / 100            */
 	clock_t adc_target = (clock_t)(zfs_txg_timeout * hz)
 	    * zfs_adc_target_sync_pct / 100;
 
+	/* ◄── ADC: initialize controller — seeds EMA, computes bounds */
 	if (zfs_adc_enable)
 	    adc_init(&adc, adc_target);
 
@@ -775,7 +824,7 @@ txg_sync_thread(void *arg)
 		}
 
 		if (tx->tx_exiting)
-			txg_thread_exit(tx, &cpr, &tx->tx_sync_thread);
+		    txg_thread_exit(tx, &cpr, &tx->tx_sync_thread);
 
 		/*
 		 * Consume the quiesced txg which has been handed off to
@@ -800,6 +849,11 @@ txg_sync_thread(void *arg)
 		delta = ddi_get_lbolt() - start;
 		spa_txg_history_fini_io(spa, ts);
 
+		/* ◄── ADC: feed measured delta into controller.
+		 *    This is the ONLY net-new call in the hot path.
+		 *    adc_update() is O(1), no allocation, no lock.	     
+		 *    Recompute target here to pick up runtime tunable changes
+		 *    (operator can adjust zfs_txg_timeout or target_pct live).  */
 		if (zfs_adc_enable) {
 		    adc_target = (clock_t)(zfs_txg_timeout * hz)
 			* zfs_adc_target_sync_pct / 100;

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -118,12 +118,15 @@ int zfs_txg_timeout = 1;	/* max seconds worth of delta per txg */
 kstat_t* dd_ksp;
 int64_t kstat_adc_target = 0;
 int64_t kstat_spa_sync_time = 0;
-int64_t kstat_data_flushed_per_sync = 0;
+uint64_t kstat_data_flushed_per_sync = 0;
+uint64_t kstat_total_dirty_data = 0;
 
 dynamic_dirty_data_stats_t dynamic_dirty_data_stats = {
     { "adc_target",	KSTAT_DATA_INT64 },
     { "spa_sync_time",	KSTAT_DATA_INT64 },
-    { "data_flushed_per_sync",	KSTAT_DATA_INT64 },
+    { "data_flushed_per_sync",	KSTAT_DATA_UINT64 },
+    { "total_dirty_data",	KSTAT_DATA_UINT64 },
+
 };
 /*
  * Target spa_sync duration as a fraction of zfs_txg_timeout.
@@ -185,8 +188,10 @@ dynamic_dirty_data_kstat_update(kstat_t* ksp, int rw) {
 	kstat_adc_target;
     as->spa_sync_time.value.i64 =
 	kstat_spa_sync_time;
-    as->data_flushed_per_sync.value.i64 =
+    as->data_flushed_per_sync.value.ui64 =
 	kstat_data_flushed_per_sync;
+    as->total_dirty_data.value.ui64 =
+	kstat_total_dirty_data;
 
     return (0);
 }
@@ -253,7 +258,7 @@ adc_init(txg_adc_t* adc, clock_t target_ticks)
  */
 static void
 adc_update(txg_adc_t* adc, uint64_t txg,
-    clock_t raw_delta, clock_t target_ticks, int64_t data_flushed)
+    clock_t raw_delta, clock_t target_ticks, uint64_t data_flushed, uint64_t total_dirty)
 {
     int64_t  error;         /* normalized error × 1000             */
     int64_t  p_term;        /* proportional correction             */
@@ -266,6 +271,7 @@ adc_update(txg_adc_t* adc, uint64_t txg,
     kstat_adc_target = (long)(((uint64_t)target_ticks * 1000ULL) / hz);
     kstat_spa_sync_time = (long)(((uint64_t)raw_delta * 1000ULL) / hz);
     kstat_data_flushed_per_sync = data_flushed;
+    kstat_total_dirty_data = total_dirty;
 
     adc->adc_n_syncs++;
 
@@ -806,20 +812,20 @@ txg_sync_thread(void *arg)
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 	clock_t start, delta;
-	/* ◄── ADC: declare controller state — stack allocated,
-	*      zero overhead when zfs_adc_enable == 0           */
+	/* ADC: declare controller state — stack allocated,
+	* zero overhead when zfs_adc_enable == 0           */
 	txg_adc_t    adc;
 
 	(void) spl_fstrans_mark();
 	txg_thread_enter(tx, &cpr);
 
 	start = delta = 0;
-	/* ◄── ADC: compute target once; recomputed if timeout changes.
-	*    target = zfs_txg_timeout × target_pct / 100            */
+	/* ADC: compute target once; recomputed if timeout changes.
+	* target = zfs_txg_timeout × target_pct / 100            */
 	clock_t adc_target = (clock_t)(zfs_txg_timeout * hz)
 	    * zfs_adc_target_sync_pct / 100;
 
-	/* ◄── ADC: initialize controller — seeds EMA, computes bounds */
+	/* ADC: initialize controller — seeds EMA, computes bounds */
 	if (zfs_adc_enable)
 	    adc_init(&adc, adc_target);
 
@@ -881,13 +887,14 @@ txg_sync_thread(void *arg)
 		mutex_exit(&tx->tx_sync_lock);
 
 		txg_stat_t *ts = spa_txg_history_init_io(spa, txg, dp);
-		int64_t dirty_flushed = spa->spa_dsl_pool->dp_dirty_pertxg[txg & TXG_MASK];
+		uint64_t dirty_flushed = spa->spa_dsl_pool->dp_dirty_pertxg[txg & TXG_MASK];
+		uint64_t total_dirty = dp->dp_dirty_total;
 		start = ddi_get_lbolt();
 		spa_sync(spa, txg);
 		delta = ddi_get_lbolt() - start;
 		spa_txg_history_fini_io(spa, ts);
 
-		/* ◄── ADC: feed measured delta into controller.
+		/*    ADC: feed measured delta into controller.
 		 *    This is the ONLY net-new call in the hot path.
 		 *    adc_update() is O(1), no allocation, no lock.	     
 		 *    Recompute target here to pick up runtime tunable changes
@@ -895,7 +902,7 @@ txg_sync_thread(void *arg)
 		if (zfs_adc_enable) {
 		    adc_target = (clock_t)(zfs_txg_timeout * hz)
 			* zfs_adc_target_sync_pct / 100;
-		    adc_update(&adc, txg, delta, adc_target, dirty_flushed);
+		    adc_update(&adc, txg, delta, adc_target, dirty_flushed, total_dirty);
 		}
 
 		mutex_enter(&tx->tx_sync_lock);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -213,8 +213,9 @@ txg_sync_start(dsl_pool_t *dp)
 	 * 32-bit x86.  This is due in part to nested pools and
 	 * scrub_visitbp() recursion.
 	 */
+
 	tx->tx_sync_thread = thread_create(NULL, 0, txg_sync_thread,
-	    dp, 0, &p0, TS_RUN, defclsyspri);
+	    dp, 0, &p0, TS_RUN, maxclsyspri);
 
 	mutex_exit(&tx->tx_sync_lock);
 }

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -115,7 +115,16 @@ static void txg_quiesce_thread(void *arg);
 int zfs_txg_timeout = 1;	/* max seconds worth of delta per txg */
 
 #define DIRTY_FLOOR_BYTES       (153ULL << 20)
+kstat_t* dd_ksp;
+int64_t kstat_adc_target = 0;
+int64_t kstat_spa_sync_time = 0;
+int64_t kstat_data_flushed_per_sync = 0;
 
+dynamic_dirty_data_stats_t dynamic_dirty_data_stats = {
+    { "adc_target",	KSTAT_DATA_INT64 },
+    { "spa_sync_time",	KSTAT_DATA_INT64 },
+    { "data_flushed_per_sync",	KSTAT_DATA_INT64 },
+};
 /*
  * Target spa_sync duration as a fraction of zfs_txg_timeout.
  * 75 = target 75% of timeout. This headroom allows for burst
@@ -166,6 +175,21 @@ typedef struct {
     int64_t     adc_last_d;         /* last D term for debug       */
 } txg_adc_t;
 
+static int
+dynamic_dirty_data_kstat_update(kstat_t* ksp, int rw) {
+    dynamic_dirty_data_stats_t* as = ksp->ks_data;
+
+    if (rw == KSTAT_WRITE)
+	return (SET_ERROR(EACCES));
+    as->adc_target.value.i64 =
+	kstat_adc_target;
+    as->spa_sync_time.value.i64 =
+	kstat_spa_sync_time;
+    as->data_flushed_per_sync.value.i64 =
+	kstat_data_flushed_per_sync;
+
+    return (0);
+}
 /*
  * adc_ema — Exponential moving average, integer arithmetic.
  *
@@ -205,6 +229,15 @@ adc_init(txg_adc_t* adc, clock_t target_ticks)
     adc->adc_ema_delta = target_ticks;
     adc->adc_prev_error = 0;
     adc->adc_integral = 0;
+
+    dd_ksp = kstat_create("zfs", 0, "dynamic_dirty_data_stats", "misc", KSTAT_TYPE_NAMED,
+	sizeof(dynamic_dirty_data_stats) / sizeof(kstat_named_t), KSTAT_FLAG_VIRTUAL);
+
+    if (dd_ksp != NULL) {
+	dd_ksp->ks_data = &dynamic_dirty_data_stats;
+	dd_ksp->ks_update = dynamic_dirty_data_kstat_update;
+	kstat_install(dd_ksp);
+    }
 }
 
 /*
@@ -220,7 +253,7 @@ adc_init(txg_adc_t* adc, clock_t target_ticks)
  */
 static void
 adc_update(txg_adc_t* adc, uint64_t txg,
-    clock_t raw_delta, clock_t target_ticks)
+    clock_t raw_delta, clock_t target_ticks, int64_t data_flushed)
 {
     int64_t  error;         /* normalized error × 1000             */
     int64_t  p_term;        /* proportional correction             */
@@ -229,6 +262,10 @@ adc_update(txg_adc_t* adc, uint64_t txg,
     int64_t  pid_out;       /* combined PID output                 */
     int64_t  adjustment;    /* byte delta for dirty_max            */
     uint64_t cur, proposed, next;
+
+    kstat_adc_target = (long)(((uint64_t)target_ticks * 1000ULL) / hz);
+    kstat_spa_sync_time = (long)(((uint64_t)raw_delta * 1000ULL) / hz);
+    kstat_data_flushed_per_sync = data_flushed;
 
     adc->adc_n_syncs++;
 
@@ -844,6 +881,7 @@ txg_sync_thread(void *arg)
 		mutex_exit(&tx->tx_sync_lock);
 
 		txg_stat_t *ts = spa_txg_history_init_io(spa, txg, dp);
+		int64_t dirty_flushed = spa->spa_dsl_pool->dp_dirty_pertxg[txg & TXG_MASK];
 		start = ddi_get_lbolt();
 		spa_sync(spa, txg);
 		delta = ddi_get_lbolt() - start;
@@ -857,7 +895,7 @@ txg_sync_thread(void *arg)
 		if (zfs_adc_enable) {
 		    adc_target = (clock_t)(zfs_txg_timeout * hz)
 			* zfs_adc_target_sync_pct / 100;
-		    adc_update(&adc, txg, delta, adc_target);
+		    adc_update(&adc, txg, delta, adc_target, dirty_flushed);
 		}
 
 		mutex_enter(&tx->tx_sync_lock);

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -113,6 +113,203 @@ static void txg_quiesce_thread(void *arg);
 
 int zfs_txg_timeout = 1;	/* max seconds worth of delta per txg */
 
+#define DIRTY_FLOOR_BYTES       (153ULL << 20)
+#define DIRTY_CEIL_BYTES        (4ULL << 30)
+uint_t zfs_adc_target_sync_pct = 75;
+/* PID gains, all scaled ×1000 to avoid floating point */
+int zfs_adc_kp = 200;   /* Proportional: main corrective force    */
+int zfs_adc_ki = 15;    /* Integral: eliminates steady-state bias  */
+int zfs_adc_kd = 100;   /* Derivative: damping against oscillation */
+
+/* EMA smoothing window in TXG count */
+uint_t zfs_adc_ema_alpha_pct = 25;  /* 25% weight on new sample   */
+/* Minimum TXGs between dirty_max updates (anti-flapping) */
+uint_t zfs_adc_holdoff_txgs = 2;
+/* Master enable — 0 reverts to stock ZFS behavior instantly */
+int zfs_adc_enable = 1;
+
+typedef struct {
+    /* PID state */
+    int64_t     adc_integral;       /* accumulated error (I term)  */
+    int64_t     adc_prev_error;     /* last error sample (D term)  */
+    clock_t     adc_ema_delta;      /* smoothed spa_sync duration  */
+    uint64_t    adc_last_txg;       /* TXG of last adjustment      */
+
+    /* Bounds in bytes, computed once from physmem */
+    uint64_t    adc_min_dirty;
+    uint64_t    adc_max_dirty;
+
+    /* Diagnostics / kstat shadow */
+    uint64_t    adc_n_syncs;        /* total TXGs observed         */
+    uint64_t    adc_n_raised;       /* times dirty_max was raised  */
+    uint64_t    adc_n_lowered;      /* times dirty_max was lowered */
+    uint64_t    adc_n_clamped;      /* times a bound was hit       */
+    int64_t     adc_last_p;         /* last P term for debug       */
+    int64_t     adc_last_i;         /* last I term for debug       */
+    int64_t     adc_last_d;         /* last D term for debug       */
+} txg_adc_t;
+
+static inline clock_t
+adc_ema(clock_t prev, clock_t sample, uint_t alpha_pct)
+{
+    return (prev + (clock_t)(((int64_t)sample - prev)
+	* alpha_pct / 100));
+}
+
+static void
+adc_init(txg_adc_t* adc, clock_t target_ticks)
+{    
+    bzero(adc, sizeof(*adc));
+
+    adc->adc_min_dirty = DIRTY_FLOOR_BYTES;
+    adc->adc_max_dirty = DIRTY_CEIL_BYTES;
+
+    /* Defensive: ensure min < max regardless of tunable misconfiguration */
+    if (adc->adc_min_dirty >= adc->adc_max_dirty)
+	adc->adc_min_dirty = adc->adc_max_dirty / 8;
+
+    /* Seed EMA at target — controller starts in steady state */
+    adc->adc_ema_delta = target_ticks;
+    adc->adc_prev_error = 0;
+    adc->adc_integral = 0;
+}
+
+static void
+adc_update(txg_adc_t* adc, uint64_t txg,
+    clock_t raw_delta, clock_t target_ticks)
+{
+    int64_t  error;         /* normalized error × 1000             */
+    int64_t  p_term;        /* proportional correction             */
+    int64_t  i_term;        /* integral correction                 */
+    int64_t  d_term;        /* derivative correction               */
+    int64_t  pid_out;       /* combined PID output                 */
+    int64_t  adjustment;    /* byte delta for dirty_max            */
+    uint64_t cur, proposed, next;
+
+    adc->adc_n_syncs++;
+
+    /* Step 1: Update smoothed sync duration via EMA */
+    adc->adc_ema_delta = adc_ema(adc->adc_ema_delta,
+	raw_delta, zfs_adc_ema_alpha_pct);
+
+    /* Step 2: Enforce adjustment holdoff (anti-flapping) */
+    if (adc->adc_last_txg != 0 &&
+	(txg - adc->adc_last_txg) < zfs_adc_holdoff_txgs)
+	return;
+
+    /* Step 3: Compute normalized error
+     *
+     * error = (ema_delta - target) / target × 1000
+     *
+     *  > 0 : sync taking too long → dirty_max too high → must shrink
+     *  < 0 : sync finishing early → dirty_max too low  → can grow
+     *  = 0 : perfect operating point
+     *
+     * Example: ema=6s, target=5s → error = +200 (20% over)
+     * Example: ema=3s, target=5s → error = -400 (40% under)
+     */
+    if (target_ticks == 0)
+	return; /* Safety: avoid divide-by-zero on misconfiguration */
+
+    error = ((int64_t)adc->adc_ema_delta - (int64_t)target_ticks)
+	* 1000LL / (int64_t)target_ticks;
+
+    /* Step 4: P term — immediate response to current error */
+    p_term = (int64_t)zfs_adc_kp * error / 1000LL;
+
+    /* Step 5: I term — accumulate to eliminate steady-state offset
+     *
+     * Anti-windup clamp: prevents integral from growing unboundedly
+     * during sustained overload (e.g., pool degraded, resilver running).
+     * Clamped at ±(30 × Kp) which limits I contribution to ≤3× P max.
+     */
+    adc->adc_integral += error;
+    {
+	int64_t windup_limit = 30LL * (int64_t)zfs_adc_kp;
+	if (adc->adc_integral > windup_limit) adc->adc_integral = windup_limit;
+	if (adc->adc_integral < -windup_limit) adc->adc_integral = -windup_limit;
+    }
+    i_term = (int64_t)zfs_adc_ki * adc->adc_integral / 1000LL;
+
+    /* Step 6: D term — dampen oscillation via rate-of-change */
+    d_term = (int64_t)zfs_adc_kd
+	* (error - adc->adc_prev_error) / 1000LL;
+    adc->adc_prev_error = error;
+
+    /* Save for diagnostics */
+    adc->adc_last_p = p_term;
+    adc->adc_last_i = i_term;
+    adc->adc_last_d = d_term;
+
+    /* Step 7: Combine PID output
+     *
+     * pid_out > 0 → sync was slow → DECREASE dirty_max
+     * pid_out < 0 → sync was fast → INCREASE dirty_max
+     * (sign inversion applied in Step 8)
+     */
+    pid_out = p_term + i_term + d_term;
+
+    if (pid_out == 0)
+	return;
+
+    /* Step 8: Convert PID output to byte adjustment
+     *
+     * adjustment = -(pid_out / 1000) × dirty_max × step_scale
+     *
+     * pid_out is in units of 0.1% so dividing by 1000 gives fraction.
+     * Maximum single-step is capped at 20% of current dirty_max to
+     * prevent catastrophic collapse from one anomalous TXG.
+     */
+    cur = zfs_dirty_data_max;
+
+    adjustment = -((int64_t)cur / 1000LL) * pid_out;
+
+    /* Cap single-step adjustment at ±20% of current dirty_max */
+    {
+	int64_t max_step = (int64_t)(cur / 5);
+	if (adjustment > max_step) adjustment = max_step;
+	if (adjustment < -max_step) adjustment = -max_step;
+    }
+
+    /* Step 9: Apply bounds */
+    proposed = (int64_t)cur + adjustment;
+
+    if (proposed <= adc->adc_min_dirty) {
+	next = adc->adc_min_dirty;
+	adc->adc_n_clamped++;
+    }
+    else if (proposed >= adc->adc_max_dirty) {
+	next = adc->adc_max_dirty;
+	adc->adc_n_clamped++;
+    }
+    else {
+	next = proposed;
+    }
+
+    /* Step 10: Commit — single store, visible to txg_delay() immediately */
+    if (next != cur) {
+	zfs_dirty_data_max = next;
+	adc->adc_last_txg = txg;
+	if (next > cur) adc->adc_n_raised++;
+	else            adc->adc_n_lowered++;
+
+	zfs_dbgmsg("txg_adc txg=%llu ema_delta=%ldms target=%ldms "
+	    "err=%lld P=%lld I=%lld D=%lld "
+	    "dirty_max %lluMB→%lluMB",
+	    (u_longlong_t)txg,
+	    (long)(((uint64_t)adc->adc_ema_delta * 1000ULL) / hz),
+	    (long)(((uint64_t)target_ticks * 1000ULL) / hz),
+	    (longlong_t)error,
+	    (longlong_t)p_term,
+	    (longlong_t)i_term,
+	    (longlong_t)d_term,
+	    (u_longlong_t)(cur >> 20),
+	    (u_longlong_t)(next >> 20));
+    }
+}
+
+
+
 /*
  * Prepare the txg subsystem.
  */
@@ -531,11 +728,18 @@ txg_sync_thread(void *arg)
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 	clock_t start, delta;
+	txg_adc_t    adc;
 
 	(void) spl_fstrans_mark();
 	txg_thread_enter(tx, &cpr);
 
 	start = delta = 0;
+	clock_t adc_target = (clock_t)(zfs_txg_timeout * hz)
+	    * zfs_adc_target_sync_pct / 100;
+
+	if (zfs_adc_enable)
+	    adc_init(&adc, adc_target);
+
 	for (;;) {
 		clock_t timeout = zfs_txg_timeout * hz;
 		clock_t timer;
@@ -598,6 +802,12 @@ txg_sync_thread(void *arg)
 		spa_sync(spa, txg);
 		delta = ddi_get_lbolt() - start;
 		spa_txg_history_fini_io(spa, ts);
+
+		if (zfs_adc_enable) {
+		    adc_target = (clock_t)(zfs_txg_timeout * hz)
+			* zfs_adc_target_sync_pct / 100;
+		    adc_update(&adc, txg, delta, adc_target);
+		}
 
 		mutex_enter(&tx->tx_sync_lock);
 		tx->tx_synced_txg = txg;

--- a/module/zfs/txg.c
+++ b/module/zfs/txg.c
@@ -307,9 +307,6 @@ adc_update(txg_adc_t* adc, uint64_t txg,
 	    (u_longlong_t)(next >> 20));
     }
 }
-
-
-
 /*
  * Prepare the txg subsystem.
  */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change addresses the SSV-25461 ZFSin high latency issue after restart 

### Description
<!--- Describe your changes in detail -->
Here is the detailed list of changes that were added to address the issue
1. spl_abd_prealloc_thread which will preallocate memory upto arc_max in abd_cache during boot time to warm cache.
2.  spl_free_wrapper and spl_free_manual_pressure_wrapper logic changed to tell system not to account free warm memory in abd_cache as used, thereby not creating a low on memory panic just after reboot.
3. Dynamic dirty max adjustment logic incorporated in txg_sync_thread, which will dynamically adjust zfs_dirty_data_max based on spa_sync flush time (Although this works well without mirror special devices, future changes will modify this code to work for MSD as well).
4. Relevant kstat data added regarding dynamic dirty code for better debugging.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Testing has been done in two phases
1. For high latency, running FIO with 1mb block size has been performed and compared the same test results with old driver.
2. For performance testing, Running vdbench on 4 vdisks (ILD,ILC,ILDC,RAW) parallely with different workloads has been performed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
